### PR TITLE
PRNG cleanup and tests for NoisyLTFArray

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ All contributions receive warm welcome! Please obey the coding standards within 
 
 If you're using pypuf in your research, please let us know so we can link to your work here.
 
+### Contribution quick check list
+
+ * Is your contribution GPLv3 compartible?
+ * Update README.md accordingly
+ * Document new code, update code comments for changed code
+ * Provide tests for your code
+ * Do not use `numpy.random` directly; always use an `numpy.random.RandomState` instance.
+
 ## Authors
 
 Significant contribution to this project are due to (in chronological order):

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ pypuf is primarily designed as an API. However, it provides a subset of its feat
 
 #### Example Usage
 
-Example usage of `sim_learn` that simulates a 64 bit 2-xor Arbiter PUF and learns it to approx. 98% from 12000 challenge response pairs: `python3 sim_learn.py 64 2 atf xor 12000 1 0xdead 0xbeef`
+Example usage of `sim_learn` that simulates a 64 bit 2-xor Arbiter PUF and learns it to approx. 98% from 12000 challenge response pairs: `python3 sim_learn.py 64 2 atf xor 12000 1 1 0xdead 0xbeef`
 
 ### API
 

--- a/pypuf/learner/regression/logistic_regression.py
+++ b/pypuf/learner/regression/logistic_regression.py
@@ -1,5 +1,6 @@
 from sys import stderr
 from numpy import sign, dot, around, exp, array, seterr, minimum, abs, full, count_nonzero, amin, amax, double
+from numpy.random import RandomState
 from pypuf.learner.base import Learner
 from pypuf.simulation.arbiter_based.ltfarray import LTFArray
 from pypuf.tools import compare_functions
@@ -84,7 +85,7 @@ class LogisticRegression(Learner):
 
             return self.step
 
-    def __init__(self, t_set, n, k, transformation=LTFArray.transform_id, combiner=LTFArray.combiner_xor, weights_mu=0, weights_sigma=1):
+    def __init__(self, t_set, n, k, transformation=LTFArray.transform_id, combiner=LTFArray.combiner_xor, weights_mu=0, weights_sigma=1, weights_prng=RandomState()):
         """
         Initialize a LTF Array Logistic Regression Learner for the specified LTF Array.
 
@@ -94,7 +95,8 @@ class LogisticRegression(Learner):
         :param transformation: Input transformation used by the LTF Array
         :param combiner: Combiner Function used by the LTF Array (Note that not all combiner functions are supported by this class.)
         :param weights_mu: mean of the Gaussian that is used to choose the initial model
-        :param weights_sigma: standard deviation of the Gaussian that is used to choose the inital model
+        :param weights_sigma: standard deviation of the Gaussian that is used to choose the initial model
+        :param weights_prng: PRNG to draw the initial model from. Defaults to fresh `numpy.random.RandomState` instance.
         """
         self.iteration_count = 0
         self.training_set = t_set
@@ -102,6 +104,7 @@ class LogisticRegression(Learner):
         self.k = k
         self.weights_mu = weights_mu
         self.weights_sigma = weights_sigma
+        self.weights_prng = weights_prng
         self.iteration_limit = 10000
         self.convergence_decimals = 3
         self.sign_combined_model_responses = None
@@ -196,7 +199,7 @@ class LogisticRegression(Learner):
 
         # we start with a random model
         model = LTFArray(
-            weight_array=LTFArray.normal_weights(self.n, self.k, self.weights_mu, self.weights_sigma),
+            weight_array=LTFArray.normal_weights(self.n, self.k, self.weights_mu, self.weights_sigma, self.weight_prng),
             transform=self.transformation,
             combiner=self.combiner,
         )

--- a/pypuf/simulation/arbiter_based/ltfarray.py
+++ b/pypuf/simulation/arbiter_based/ltfarray.py
@@ -275,4 +275,4 @@ class NoisyLTFArray(LTFArray):
         initializing the NoisyLTFArray.
         """
         noise = self.random.normal(loc=0, scale=self.sigma_noise, size=(1, self.k))
-        return super().ltf_eval(self, inputs) + noise
+        return super().ltf_eval(inputs) + noise

--- a/pypuf/tools.py
+++ b/pypuf/tools.py
@@ -1,12 +1,17 @@
-from numpy import random, count_nonzero, array, append
+from numpy import count_nonzero, array, append
+from numpy.random import RandomState
 import itertools
 
 
-def random_input(n):
+def random_input(n, random_instance=RandomState()):
     """
     returns a random {-1,1}-vector of length `n`.
+
+    `choice` method of optionally provided PRNG is used.
+     If no PRNG provided, a fresh `numpy.random.RandomState`
+     instance is used.
     """
-    return random.choice((-1, +1), n)
+    return random_instance.choice((-1, +1), n)
 
 
 def all_inputs(n):
@@ -16,12 +21,14 @@ def all_inputs(n):
     return itertools.product((-1, +1), repeat=n)
 
 
-def random_inputs(n, num):
+def random_inputs(n, num, random_instance=RandomState()):
     """
     returns an iterator for a random sample of {-1,1}-vectors of length `n` (with replacement).
+
+    If no PRNG provided, a fresh `numpy.random.RandomState` instance is used.
     """
     for i in range(num):
-        yield random_input(n)
+        yield random_input(n, random_instance)
 
 
 def sample_inputs(n, num):

--- a/sim_learn.py
+++ b/sim_learn.py
@@ -9,7 +9,7 @@ from sys import argv, stdout, stderr
 if len(argv) != 10:
     stderr.write('LTF Array Simulator and Logistic Regression Learner\n')
     stderr.write('Usage:\n')
-    stderr.write('sim_learn.py n k transformation combiner N restarts seed_ltf seed_model\n')
+    stderr.write('sim_learn.py n k transformation combiner N restarts seed_instance seed_model\n')
     stderr.write('               n: number of bits per Arbiter chain\n')
     stderr.write('               k: number of Arbiter chains\n')
     stderr.write('  transformation: used to transform input before it is used in LTFs\n')
@@ -35,7 +35,7 @@ if len(argv) != 10:
     stderr.write('                  use float number x, 0<x<1 to repeat until given accuracy\n')
     stderr.write('       instances: number of repeated initializations the instance\n')
     stderr.write('                  The number total learning attempts is restarts*instances.\n')
-    stderr.write('        seed_ltf: random seed used for LTF array instance\n')
+    stderr.write('   seed_instance: random seed used for LTF array instance\n')
     stderr.write('      seed_model: random seed used for the model in first learning attempt\n')
     quit(1)
 

--- a/test/test_simulation.py
+++ b/test/test_simulation.py
@@ -2,7 +2,8 @@ import unittest
 from pypuf.simulation.arbiter_based.ltfarray import LTFArray
 from pypuf import tools
 from numpy.testing import assert_array_equal
-from numpy import shape, dot, random, full, tile, array, transpose, around
+from numpy import shape, dot, array, around
+from numpy.random import RandomState
 
 
 class TestCombiner(unittest.TestCase):
@@ -274,7 +275,7 @@ class TestLTFArray(unittest.TestCase):
             weight_array = LTFArray.normal_weights(n, k, mu, sigma)
 
             input_len = n-1 if bias else n
-            inputs = random.choice([-1,+1], (N, input_len))
+            inputs = RandomState(seed=0xBAADA555).choice([-1,+1], (N, input_len))  # bad ass testing
 
             biased_ltf_array = LTFArray(
                 weight_array = weight_array,
@@ -306,7 +307,6 @@ class TestLTFArray(unittest.TestCase):
     def test_ltf_eval(self):
         """
         Test ltf_eval for correct evaluation of LTFs.
-        This is a probabilistic test, relying on random input.
         """
 
         N = 100  # number of random inputs per test set
@@ -324,7 +324,7 @@ class TestLTFArray(unittest.TestCase):
             mu = test_parameters[2]
             sigma = test_parameters[3]
 
-            inputs = random.choice([-1, +1], (N, n))
+            inputs = RandomState(seed=0xCAFED00D).choice([-1, +1], (N, n))
 
             ltf_array = LTFArray(
                 weight_array=LTFArray.normal_weights(n, k, mu, sigma),


### PR DESCRIPTION
This PR removes all usage of `numpy.random` across the project. Instead, all pseudorandom draws have been replaced with individual PNRG instances (using `numpy.random.RandomState`). This removes the possibility of interference of pseudorandom draws across different methods in the project and hence increases reproducibility of results.

This change enabled me to add a unit test for the `ltf_eval` method of `NoisyLTFArray`, that was untested until now. It also includes a minor bugfix for `NoisyLTFArray`.

The PR includes the minor bug fix #23 and improves doc wording as well as updated contribution guidelines.

I plan on rebasing and restructuring the commits, but will leave them fine granular for now to make the review easier.

Merging sould be delayed until we decided over #20, for now this PR is against the branch of #20 to make clear what's new.