### PR TITLE
Revert "PRNG cleanup and tests for NoisyLTFArray"

### DIFF
--- a/pypuf/learner/regression/logistic_regression.py
+++ b/pypuf/learner/regression/logistic_regression.py
@@ -199,7 +199,7 @@ class LogisticRegression(Learner):
 
         # we start with a random model
         model = LTFArray(
-            weight_array=LTFArray.normal_weights(self.n, self.k, self.weights_mu, self.weights_sigma, self.weight_prng),
+            weight_array=LTFArray.normal_weights(self.n, self.k, self.weights_mu, self.weights_sigma, self.weights_prng),
             transform=self.transformation,
             combiner=self.combiner,
         )

--- a/pypuf/learner/regression/logistic_regression.py
+++ b/pypuf/learner/regression/logistic_regression.py
@@ -172,7 +172,7 @@ class LogisticRegression(Learner):
         # in a multiprocessing scenario the object references would not be the same!
         if compare_functions(self.combiner, LTFArray.combiner_xor):
             model_gradient = model_gradient_xor
-        elif compare_functions(self.combiner == LTFArray.combiner_ip_mod2):
+        elif compare_functions(self.combiner, LTFArray.combiner_ip_mod2):
             model_gradient = model_gradient_ip_mod2
         else:
             raise Exception('No gradient function known for combiner %s' % self.combiner)

--- a/sim_learn.py
+++ b/sim_learn.py
@@ -6,148 +6,158 @@ from pypuf import tools
 import time
 from sys import argv, stdout, stderr
 
-if len(argv) != 10:
-    stderr.write('LTF Array Simulator and Logistic Regression Learner\n')
-    stderr.write('Usage:\n')
-    stderr.write('sim_learn.py n k transformation combiner N restarts seed_instance seed_model\n')
-    stderr.write('               n: number of bits per Arbiter chain\n')
-    stderr.write('               k: number of Arbiter chains\n')
-    stderr.write('  transformation: used to transform input before it is used in LTFs\n')
-    stderr.write('                  currently available:\n')
-    stderr.write('                  - id  -- does nothing at all\n')
-    stderr.write('                  - atf -- convert according to "natural" Arbiter chain\n')
-    stderr.write('                           implementation\n')
-    stderr.write('                  - mm  -- designed to achieve maximum PTF expansion length\n')
-    stderr.write('                           only implemented for k=2 and even n\n')
-    stderr.write('                  - lightweight_secure -- design by Majzoobi et al. 2008\n')
-    stderr.write('                                          only implemented for even n\n')
-    stderr.write('                  - 1_n_bent -- one LTF gets "bent" input, the others id\n')
-    stderr.write('                  - 1_1_bent -- one bit gets "bent" input, the others id,\n')
-    stderr.write('                                this is proven to have maximum PTF\n')
-    stderr.write('                                length for the model\n')
-    stderr.write('        combiner: used to combine the output bits to a single bit\n')
-    stderr.write('                  currently available:\n')
-    stderr.write('                  - xor     -- output the parity of all output bits\n')
-    stderr.write('                  - ip_mod2 -- output the inner product mod 2 of all output\n')
-    stderr.write('                               bits (even n only)\n')
-    stderr.write('               N: number of challenge response pairs in the training set\n')
-    stderr.write('        restarts: number of repeated initializations the learner\n')
-    stderr.write('                  use float number x, 0<x<1 to repeat until given accuracy\n')
-    stderr.write('       instances: number of repeated initializations the instance\n')
-    stderr.write('                  The number total learning attempts is restarts*instances.\n')
-    stderr.write('   seed_instance: random seed used for LTF array instance\n')
-    stderr.write('      seed_model: random seed used for the model in first learning attempt\n')
-    quit(1)
 
-n = int(argv[1])
-k = int(argv[2])
-transformation_name = argv[3]
-combiner_name = argv[4]
-N = int(argv[5])
+def main(args):
 
-if float(argv[6]) < 1:
-    restarts = float('inf')
-    convergence = float(argv[6])
-else:
-    restarts = int(argv[6])
-    convergence = 1.1
+    if len(args) != 10:
+        stderr.write('LTF Array Simulator and Logistic Regression Learner\n')
+        stderr.write('Usage:\n')
+        stderr.write('sim_learn.py n k transformation combiner N restarts seed_instance seed_model\n')
+        stderr.write('               n: number of bits per Arbiter chain\n')
+        stderr.write('               k: number of Arbiter chains\n')
+        stderr.write('  transformation: used to transform input before it is used in LTFs\n')
+        stderr.write('                  currently available:\n')
+        stderr.write('                  - id  -- does nothing at all\n')
+        stderr.write('                  - atf -- convert according to "natural" Arbiter chain\n')
+        stderr.write('                           implementation\n')
+        stderr.write('                  - mm  -- designed to achieve maximum PTF expansion length\n')
+        stderr.write('                           only implemented for k=2 and even n\n')
+        stderr.write('                  - lightweight_secure -- design by Majzoobi et al. 2008\n')
+        stderr.write('                                          only implemented for even n\n')
+        stderr.write('                  - 1_n_bent -- one LTF gets "bent" input, the others id\n')
+        stderr.write('                  - 1_1_bent -- one bit gets "bent" input, the others id,\n')
+        stderr.write('                                this is proven to have maximum PTF\n')
+        stderr.write('                                length for the model\n')
+        stderr.write('        combiner: used to combine the output bits to a single bit\n')
+        stderr.write('                  currently available:\n')
+        stderr.write('                  - xor     -- output the parity of all output bits\n')
+        stderr.write('                  - ip_mod2 -- output the inner product mod 2 of all output\n')
+        stderr.write('                               bits (even n only)\n')
+        stderr.write('               N: number of challenge response pairs in the training set\n')
+        stderr.write('        restarts: number of repeated initializations the learner\n')
+        stderr.write('                  use float number x, 0<x<1 to repeat until given accuracy\n')
+        stderr.write('       instances: number of repeated initializations the instance\n')
+        stderr.write('                  The number total learning attempts is restarts*instances.\n')
+        stderr.write('   seed_instance: random seed used for LTF array instance\n')
+        stderr.write('      seed_model: random seed used for the model in first learning attempt\n')
+        quit(1)
 
-instances = int(argv[7])
+    n = int(args[1])
+    k = int(args[2])
+    transformation_name = args[3]
+    combiner_name = args[4]
+    N = int(args[5])
 
-seed_instance = int(argv[8], 16)
-seed_model = int(argv[9], 16)
+    if float(args[6]) < 1:
+        restarts = float('inf')
+        convergence = float(args[6])
+    else:
+        restarts = int(args[6])
+        convergence = 1.1
 
-# reproduce 'random' numbers and avoid interference with other random numbers drawn
-instance_prng = RandomState(seed=seed_instance)
-model_prng = RandomState(seed=seed_model)
+    instances = int(args[7])
 
-transformation = None
-combiner = None
+    seed_instance = int(args[8], 16)
+    seed_model = int(args[9], 16)
 
-try:
-    transformation = getattr(LTFArray, 'transform_%s' % transformation_name)
-except AttributeError:
-    stderr.write('Transformation %s unknown or currently not implemented\n' % transformation_name)
-    quit()
+    # reproduce 'random' numbers and avoid interference with other random numbers drawn
+    instance_prng = RandomState(seed=seed_instance)
+    model_prng = RandomState(seed=seed_model)
 
-try:
-    combiner = getattr(LTFArray, 'combiner_%s' % combiner_name)
-except AttributeError:
-    stderr.write('Combiner %s unknown or currently not implemented\n' % combiner_name)
-    quit()
+    transformation = None
+    combiner = None
 
-stderr.write('Learning %s-bit %s XOR Arbiter PUF with %s CRPs and %s restarts.\n\n' % (n, k, N, restarts))
-stderr.write('Using\n')
-stderr.write('  transformation:       %s\n' % transformation)
-stderr.write('  combiner:             %s\n' % combiner)
-stderr.write('  instance random seed: 0x%x\n' % seed_instance)
-stderr.write('  model random seed:    0x%x\n' % seed_model)
-stderr.write('\n')
+    try:
+        transformation = getattr(LTFArray, 'transform_%s' % transformation_name)
+    except AttributeError:
+        stderr.write('Transformation %s unknown or currently not implemented\n' % transformation_name)
+        quit()
 
-accuracy = array([])
-training_times = array([])
-iterations = array([])
+    try:
+        combiner = getattr(LTFArray, 'combiner_%s' % combiner_name)
+    except AttributeError:
+        stderr.write('Combiner %s unknown or currently not implemented\n' % combiner_name)
+        quit()
 
-for j in range(instances):
+    stderr.write('Learning %s-bit %s XOR Arbiter PUF with %s CRPs and %s restarts.\n\n' % (n, k, N, restarts))
+    stderr.write('Using\n')
+    stderr.write('  transformation:       %s\n' % transformation)
+    stderr.write('  combiner:             %s\n' % combiner)
+    stderr.write('  instance random seed: 0x%x\n' % seed_instance)
+    stderr.write('  model random seed:    0x%x\n' % seed_model)
+    stderr.write('\n')
 
-    stderr.write('----------- Choosing new instance. ---------\n')
+    accuracy = array([])
+    training_times = array([])
+    iterations = array([])
 
-    instance = LTFArray(
-        weight_array=LTFArray.normal_weights(n, k, random_instance=instance_prng),
-        transform=transformation,
-        combiner=combiner,
-    )
+    for j in range(instances):
 
-    lr_learner = LogisticRegression(
-        tools.TrainingSet(instance=instance, N=N),
-        n,
-        k,
-        transformation=transformation,
-        combiner=combiner,
-        weights_prng=model_prng,
-    )
+        stderr.write('----------- Choosing new instance. ---------\n')
 
-    i = 0
-    dist = 1
+        instance = LTFArray(
+            weight_array=LTFArray.normal_weights(n, k, random_instance=instance_prng),
+            transform=transformation,
+            combiner=combiner,
+        )
 
-    while i < restarts and 1 - dist < convergence:
-        stderr.write('\r%5i/%5i         ' % (i+1, restarts if restarts < float('inf') else 0))
-        start = time.time()
-        model = lr_learner.learn()
-        end = time.time()
-        training_times = append(training_times, end - start)
-        dist = tools.approx_dist(instance, model, min(10000, 2 ** n))
-        accuracy = append(accuracy, 1 - dist)
-        iterations = append(iterations, lr_learner.iteration_count)
-        # output test result in machine-friendly format
-        # seed_ltf seed_model idx_restart n k N transformation combiner iteration_count time accuracy
-        stdout.write(' '.join(
-            [
-                '0x%x' % seed_instance,
-                '0x%x' % seed_model,
-                '%5d' % i,
-                '%3d' % n,
-                '%2d' % k,
-                '%6d' % N,
-                '%s' % transformation_name,
-                '%s' % combiner_name,
-                '%4d' % lr_learner.iteration_count,
-                '%9.3f' % (end - start),
-                '%1.5f' % (1 - dist),
-            ]
-        ) + '\n')
-        #stderr.write('training time:                % 5.3fs' % (end - start))
-        #stderr.write('min training distance:        % 5.3f' % lr_learner.min_distance)
-        #stderr.write('test distance (1000 samples): % 5.3f\n' % dist)
-        i += 1
+        lr_learner = LogisticRegression(
+            tools.TrainingSet(instance=instance, N=N),
+            n,
+            k,
+            transformation=transformation,
+            combiner=combiner,
+            weights_prng=model_prng,
+        )
 
-stderr.write('\r              \r')
-stderr.write('\n\n')
-stderr.write('training times: %s\n' % training_times)
-stderr.write('iterations: %s\n' % iterations)
-stderr.write('test accuracy: %s\n' % accuracy)
-stderr.write('\n\n')
-stderr.write('min/avg/max training time  : % 9.3fs /% 9.3fs /% 9.3fs\n' % (amin(training_times), mean(training_times), amax(training_times)))
-stderr.write('min/avg/max iteration count: % 9.3f  /% 9.3f  /% 9.3f \n' % (amin(iterations), mean(iterations), amax(iterations)))
-stderr.write('min/avg/max test accuracy  : % 9.3f  /% 9.3f  /% 9.3f \n' % (amin(accuracy), mean(accuracy), amax(accuracy)))
-stderr.write('\n\n')
+        i = 0
+        dist = 1
+
+        while i < restarts and 1 - dist < convergence:
+            stderr.write('\r%5i/%5i         ' % (i+1, restarts if restarts < float('inf') else 0))
+            start = time.time()
+            model = lr_learner.learn()
+            end = time.time()
+            training_times = append(training_times, end - start)
+            dist = tools.approx_dist(instance, model, min(10000, 2 ** n))
+            accuracy = append(accuracy, 1 - dist)
+            iterations = append(iterations, lr_learner.iteration_count)
+            # output test result in machine-friendly format
+            # seed_ltf seed_model idx_restart n k N transformation combiner iteration_count time accuracy
+            stdout.write(' '.join(
+                [
+                    '0x%x' % seed_instance,
+                    '0x%x' % seed_model,
+                    '%5d' % i,
+                    '%3d' % n,
+                    '%2d' % k,
+                    '%6d' % N,
+                    '%s' % transformation_name,
+                    '%s' % combiner_name,
+                    '%4d' % lr_learner.iteration_count,
+                    '%9.3f' % (end - start),
+                    '%1.5f' % (1 - dist),
+                ]
+            ) + '\n')
+            #stderr.write('training time:                % 5.3fs' % (end - start))
+            #stderr.write('min training distance:        % 5.3f' % lr_learner.min_distance)
+            #stderr.write('test distance (1000 samples): % 5.3f\n' % dist)
+            i += 1
+
+    stderr.write('\r              \r')
+    stderr.write('\n\n')
+    stderr.write('training times: %s\n' % training_times)
+    stderr.write('iterations: %s\n' % iterations)
+    stderr.write('test accuracy: %s\n' % accuracy)
+    stderr.write('\n\n')
+    stderr.write('min/avg/max training time  : % 9.3fs /% 9.3fs /% 9.3fs\n' % (
+    amin(training_times), mean(training_times), amax(training_times)))
+    stderr.write('min/avg/max iteration count: % 9.3f  /% 9.3f  /% 9.3f \n' % (
+    amin(iterations), mean(iterations), amax(iterations)))
+    stderr.write(
+        'min/avg/max test accuracy  : % 9.3f  /% 9.3f  /% 9.3f \n' % (amin(accuracy), mean(accuracy), amax(accuracy)))
+    stderr.write('\n\n')
+
+
+if __name__ == '__main__':
+    main(argv)

--- a/test/test_logistic_regression.py
+++ b/test/test_logistic_regression.py
@@ -1,0 +1,70 @@
+import unittest
+from numpy.random import RandomState
+from pypuf.simulation.arbiter_based.ltfarray import LTFArray
+from pypuf.learner.regression.logistic_regression import LogisticRegression
+from pypuf.tools import TrainingSet
+
+
+class TestLogisticRegression(unittest.TestCase):
+    """
+        This module tests the logistic regression learner.
+    """
+    n = 16
+    k = 2
+    N = 12000
+    seed_model = 1234
+    seed_instance = 1234
+
+    def test_learn_xor(self):
+        """"
+            Stupid test which gains code coverage
+        """
+        instance_prng = RandomState(seed=TestLogisticRegression.seed_instance)
+        model_prng = RandomState(seed=TestLogisticRegression.seed_model)
+
+        instance = LTFArray(
+            weight_array=LTFArray.normal_weights(
+                TestLogisticRegression.n,
+                TestLogisticRegression.k,
+                random_instance=instance_prng
+            ),
+            transform=LTFArray.transform_id,
+            combiner=LTFArray.combiner_xor,
+        )
+
+        lr_learner = LogisticRegression(
+            TrainingSet(instance=instance, N=TestLogisticRegression.N),
+            TestLogisticRegression.n,
+            TestLogisticRegression.k,
+            transformation=LTFArray.transform_id,
+            combiner=LTFArray.combiner_xor,
+            weights_prng=model_prng,
+        )
+        lr_learner.learn()
+
+    def test_learn_ip_mod2(self):
+        """"
+            Stupid test which gains code coverage
+        """
+        instance_prng = RandomState(seed=TestLogisticRegression.seed_instance)
+        model_prng = RandomState(seed=TestLogisticRegression.seed_model)
+
+        instance = LTFArray(
+            weight_array=LTFArray.normal_weights(
+                TestLogisticRegression.n,
+                TestLogisticRegression.k,
+                random_instance=instance_prng
+            ),
+            transform=LTFArray.transform_id,
+            combiner=LTFArray.combiner_ip_mod2,
+        )
+
+        lr_learner = LogisticRegression(
+            TrainingSet(instance=instance, N=TestLogisticRegression.N),
+            TestLogisticRegression.n,
+            TestLogisticRegression.k,
+            transformation=LTFArray.transform_id,
+            combiner=LTFArray.combiner_xor,
+            weights_prng=model_prng,
+        )
+        lr_learner.learn()

--- a/test/test_sim_learn.py
+++ b/test/test_sim_learn.py
@@ -1,0 +1,42 @@
+import unittest
+import sim_learn
+
+
+class TestSimLearn(unittest.TestCase):
+    def test_id(self):
+        sim_learn.main(["sim_learn", "16", "2", "id", "xor", "12000", "1", "2", "1234", "1234"])
+
+    def test_atf(self):
+        sim_learn.main(["sim_learn", "16", "2", "atf", "xor", "12000", "1", "2", "1234", "1234"])
+
+    def test_mm(self):
+        sim_learn.main(["sim_learn", "16", "2", "mm", "xor", "12000", "1", "2", "1234", "1234"])
+
+    def test_lightweight_secure(self):
+        sim_learn.main(["sim_learn", "16", "2", "lightweight_secure", "xor", "12000", "1", "2", "1234", "1234"])
+
+    def test_1_n_bent(self):
+        sim_learn.main(["sim_learn", "16", "2", "1_n_bent", "xor", "12000", "1", "2", "1234", "1234"])
+
+    def test_1_1_bent(self):
+        sim_learn.main(["sim_learn", "16", "2", "1_1_bent", "xor", "12000", "1", "2", "1234", "1234"])
+
+    def test_ip_mod2_id(self):
+        sim_learn.main(["sim_learn", "16", "2", "id", "ip_mod2", "12000", "1", "2", "1234", "1234"])
+
+    def test_ip_mod2_atf(self):
+        sim_learn.main(["sim_learn", "16", "2", "atf", "ip_mod2", "12000", "1", "2", "1234", "1234"])
+
+    def test_ip_mod2_mm(self):
+        sim_learn.main(["sim_learn", "16", "2", "mm", "ip_mod2", "12000", "1", "2", "1234", "1234"])
+
+    def test_ip_mod2_lightweight_secure(self):
+        sim_learn.main(["sim_learn", "16", "2", "lightweight_secure", "ip_mod2", "12000", "1", "2", "1234", "1234"])
+
+    def test_ip_mod2_1_n_bent(self):
+        sim_learn.main(["sim_learn", "16", "2", "1_n_bent", "ip_mod2", "12000", "1", "2", "1234", "1234"])
+
+    def test_ip_mod2_1_1_bent(self):
+        sim_learn.main(["sim_learn", "16", "2", "1_1_bent", "ip_mod2", "12000", "1", "2", "1234", "1234"])
+
+


### PR DESCRIPTION
Reverts nils-wisiol/pypuf#24

Running the sim_learn gives me this error

```
python -m sim_learn "16" "2" "id" "xor" "12000" "1" "10" "1234" "1234" Learning 16-bit 2 XOR Arbiter PUF with 12000 CRPs and 1 restarts.

Using
  transformation:       <function LTFArray.transform_id at 0x7fcff2529ea0>
  combiner:             <function LTFArray.combiner_xor at 0x7fcff2529a60>
  instance random seed: 0x1234
  model random seed:    0x1234

----------- Choosing new instance. ---------
    1/    1         Traceback (most recent call last):
  File "/home/christoph/miniconda3/envs/pypuf/lib/python3.4/runpy.py", line 170, in _run_module_as_main
    "__main__", mod_spec)
  File "/home/christoph/miniconda3/envs/pypuf/lib/python3.4/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/christoph/arbeit/pypuf/sim_learn.py", line 116, in <module>
    model = lr_learner.learn()
  File "/home/christoph/arbeit/pypuf/pypuf/learner/regression/logistic_regression.py", line 202, in learn
    weight_array=LTFArray.normal_weights(self.n, self.k, self.weights_mu, self.weights_sigma, self.weight_prng),
AttributeError: 'LogisticRegression' object has no attribute 'weight_prng'
```

Please fix this and add a simple test that runs sim_learn.py so this will not happen again.