### PR TITLE
Reduced number of CRPs in tests to speed up tests.

### DIFF
--- a/test/test_experiment_logistic_regression.py
+++ b/test/test_experiment_logistic_regression.py
@@ -5,7 +5,7 @@ from pypuf.experiments.experiment.logistic_regression import ExperimentLogisticR
 
 class TestExperimentLogisticRegression(unittest.TestCase):
     def setUp(self):
-        self.lr16_4 = ExperimentLogisticRegression('exp1.log', 8, 2, 12000, 0xbeef, 0xbeef, LTFArray.transform_id,
+        self.lr16_4 = ExperimentLogisticRegression('exp1.log', 8, 2, 2**8, 0xbeef, 0xbeef, LTFArray.transform_id,
                                                    LTFArray.combiner_xor, restarts=6)
         self.lr16_4.analysis()
 

--- a/test/test_experimenter.py
+++ b/test/test_experimenter.py
@@ -6,15 +6,15 @@ from pypuf.experiments.experimenter import Experimenter
 
 class TestExperimenter(unittest.TestCase):
     def test_lr_experiments(self):
-        lr16_4_1 = ExperimentLogisticRegression('exp1.log', 8, 2, 12000, 0xbeef, 0xbeef, LTFArray.transform_id,
+        lr16_4_1 = ExperimentLogisticRegression('exp1.log', 8, 2, 2**8, 0xbeef, 0xbeef, LTFArray.transform_id,
                                                 LTFArray.combiner_xor, restarts=6)
-        lr16_4_2 = ExperimentLogisticRegression('exp2.log', 8, 2, 12000, 0xbeef, 0xbeef, LTFArray.transform_id,
+        lr16_4_2 = ExperimentLogisticRegression('exp2.log', 8, 2, 2**8, 0xbeef, 0xbeef, LTFArray.transform_id,
                                                 LTFArray.combiner_xor, restarts=6)
-        lr16_4_3 = ExperimentLogisticRegression('exp3.log', 8, 2, 12000, 0xbeef, 0xbeef, LTFArray.transform_id,
+        lr16_4_3 = ExperimentLogisticRegression('exp3.log', 8, 2, 2**8, 0xbeef, 0xbeef, LTFArray.transform_id,
                                                 LTFArray.combiner_xor, restarts=6)
-        lr16_4_4 = ExperimentLogisticRegression('exp4.log', 8, 2, 12000, 0xbeef, 0xbeef, LTFArray.transform_id,
+        lr16_4_4 = ExperimentLogisticRegression('exp4.log', 8, 2, 2**8, 0xbeef, 0xbeef, LTFArray.transform_id,
                                                 LTFArray.combiner_xor, restarts=6)
-        lr16_4_5 = ExperimentLogisticRegression('exp5.log', 8, 2, 12000, 0xbeef, 0xbeef, LTFArray.transform_id,
+        lr16_4_5 = ExperimentLogisticRegression('exp5.log', 8, 2, 2**8, 0xbeef, 0xbeef, LTFArray.transform_id,
                                                 LTFArray.combiner_xor, restarts=6)
         experiments = [lr16_4_1, lr16_4_2, lr16_4_3, lr16_4_4, lr16_4_5]
         experimenter = Experimenter('log', experiments)

--- a/test/test_logistic_regression.py
+++ b/test/test_logistic_regression.py
@@ -9,9 +9,9 @@ class TestLogisticRegression(unittest.TestCase):
     """
         This module tests the logistic regression learner.
     """
-    n = 16
+    n = 8
     k = 2
-    N = 12000
+    N = 2**8
     seed_model = 1234
     seed_instance = 1234
 


### PR DESCRIPTION
In two tests, the number of CRPs was (way) higher than the total number
of possible challenges. In one test, the number was higher than it had
to be.