### PR TITLE
Improve Logging: Clearer code, outputs more information better organized

### DIFF
--- a/pypuf/experiments/experiment/logistic_regression.py
+++ b/pypuf/experiments/experiment/logistic_regression.py
@@ -1,6 +1,6 @@
-import time
 from numpy.random import RandomState
 from numpy import amin, amax, mean, array, append
+from numpy.linalg import norm
 from pypuf.experiments.experiment.base import Experiment
 from pypuf.learner.regression.logistic_regression import LogisticRegression
 from pypuf.simulation.arbiter_based.ltfarray import LTFArray
@@ -12,88 +12,74 @@ class ExperimentLogisticRegression(Experiment):
         This Experiment uses the logistic regression learner on an LTFArray PUF simulation.
     """
 
-    def __init__(self, log_name, n, k, crp_count, seed_instance, seed_model, transformation, combiner,
-                 restarts=float('inf'),
-                 convergence=1.1):
-        self.log_name = log_name
+    def __init__(self, log_name, n, k, N, seed_instance, seed_model, transformation, combiner):
+        super().__init__(
+            log_name='%s.0x%x_0x%x_0_%i_%i_%i_%s_%s' % (
+                log_name,
+                seed_model,
+                seed_instance,
+                n,
+                k,
+                N,
+                transformation.__name__,
+                combiner.__name__,
+            ),
+        )
         self.n = n
         self.k = k
-        self.N = crp_count
+        self.N = N
         self.seed_instance = seed_instance
         self.instance_prng = RandomState(seed=self.seed_instance)
         self.seed_model = seed_model
         self.model_prng = RandomState(seed=self.seed_model)
-        self.restarts = restarts
-        self.convergence = convergence
         self.combiner = combiner
         self.transformation = transformation
+        self.instance = None
+        self.learner = None
+        self.model = None
+
+    def run(self):
+        """
+        Initializes the instance, the training set and the learner to then run the logistic regression
+        with the given parameters.
+        """
+        # TODO input transformation is computed twice. Add a shortcut to recycle results from the first computation
         self.instance = LTFArray(
-            weight_array=LTFArray.normal_weights(n, k, random_instance=self.instance_prng),
+            weight_array=LTFArray.normal_weights(self.n, self.k, random_instance=self.instance_prng),
             transform=self.transformation,
             combiner=self.combiner,
         )
         self.learner = LogisticRegression(
-            tools.TrainingSet(instance=self.instance, N=crp_count),
-            n,
-            k,
+            tools.TrainingSet(instance=self.instance, N=self.N),
+            self.n,
+            self.k,
             transformation=self.transformation,
             combiner=self.combiner,
-            weights_prng=self.model_prng
+            weights_prng=self.model_prng,
+            logger=self.progress_logger,
         )
-        super().__init__(self.log_name, self.learner)
-        self.min_dist = 0
-        self.test_dist = 0
-        self.accuracy = array([])
-        self.training_times = array([])
-        self.iterations = array([])
-        self.dist = 1.0
+        self.model = self.learner.learn()
 
-    def name(self):
-        return 'ExperimentLogisticRegression n={0} k={1} N={2} ' \
-               'seed_instance={3}, seed_model={4}'.format(self.n, self.k,
-                                                          self.N,
-                                                          self.seed_instance,
-                                                          self.seed_model)
+    def analyze(self):
+        """
+        Analyzes the learned result.
+        """
+        assert self.model is not None
 
-    def output_string(self):
-        msg = 'training times: {0}\n' \
-              'iterations: {1}\n' \
-              'test accuracy: {2}\n' \
-              'min/avf/max training time: {3} / {4} / {5}\n' \
-              'min/avg/max iteration count: {6} / {7} / {8}\n' \
-              'min/avg/max test accuracy: {9} / {10} / {11}'.format(
-            self.training_times,
-            self.iterations,
-            self.accuracy,
-            amin(self.training_times),
-            mean(self.training_times),
-            amax(self.training_times),
-            amin(self.iterations),
-            mean(self.iterations),
-            amax(self.iterations),
-            amin(self.accuracy),
-            mean(self.accuracy),
-            amax(self.accuracy),
+        self.result_logger.info(
+            # seed_instance  seed_model i      n      k      N      trans  comb   iter   time   accuracy  model values
+            '0x%x\t'        '0x%x\t'   '%i\t' '%i\t' '%i\t' '%i\t' '%s\t' '%s\t' '%i\t' '%f\t' '%f\t'    '%s' % (
+                self.seed_instance,
+                self.seed_model,
+                0,  # restart count, kept for compatibility to old log files
+                self.n,
+                self.k,
+                self.N,
+                self.transformation.__name__,
+                self.combiner.__name__,
+                self.learner.iteration_count,
+                self.measured_time,
+                1.0 - tools.approx_dist(self.instance, self.model, min(10000, 2 ** self.n)),
+                ','.join(map(str, self.model.weight_array.flatten() / norm(self.model.weight_array.flatten())))
+            )
         )
-        return msg
-
-    def analysis(self):
-        """
-            This method learns one instance self.restarts times or a self.convergence threshold is reached.
-            The results are saved in:
-                self.training_times
-                self.dist
-                self.accuracy
-                self.iterations
-        :return:
-        """
-        i = 0.0
-        while i < self.restarts and 1.0 - self.dist < self.convergence:
-            start = time.time()
-            model = self.learner.learn()
-            end = time.time()
-            self.training_times = append(self.training_times, end - start)
-            self.dist = tools.approx_dist(self.instance, model, min(10000, 2 ** self.n))
-            self.accuracy = append(self.accuracy, 1.0 - self.dist)
-            self.iterations = append(self.iterations, self.learner.iteration_count)
-            i += 1

--- a/pypuf/experiments/experimenter.py
+++ b/pypuf/experiments/experimenter.py
@@ -1,63 +1,65 @@
 import multiprocessing
 import logging
-from pypuf.tools import setup_logger
 
 
 class Experimenter(object):
     """
-        This class can be used to execute a list of experiments on several processors simultaneously.
+    Coordinated, parallel execution of Experiments with logging.
     """
-    # This static variable holds the message which signals the output thread that all processes are finished.
-    FINISHED = 'EXPERIMENTER FINISHED'
 
-    def __init__(self, log_name, experiments):
+    def __init__(self, log_name, experiments, cpu_limit=2**16):
         """
         :param experiments: A list of pypuf.experiments.experiment.base.Experiment
         :param log_name: A unique file path where to output should be logged.
+        :param cpu_limit: Maximum number of parallel processes that run experiments.
         """
-        self.experiments = experiments
-        self.log_name = log_name
-        setup_logger(self.log_name, self.log_name)
-        self.logger = logging.getLogger(self.log_name)
-        self._cpu_count = multiprocessing.cpu_count()
-        self.semaphore = multiprocessing.BoundedSemaphore(self._cpu_count)
-        self.out_queue = multiprocessing.Queue()
 
-    def gather_output(self, out_queue):
-        """
-            This method is used to gather all the outputs from experiments.
-        """
-        msg = out_queue.get()
-        # log the experiment output
-        while msg != Experimenter.FINISHED or out_queue.qsize() > 0:
-            # log the output
-            self.logger.info(msg+'\n')
-            msg = out_queue.get()
+        # Store experiments list
+        self.experiments = experiments
+
+        # Setup logging to both file and console
+        file_handler = logging.FileHandler(filename='%s.log' % log_name, mode='w')
+        file_handler.setLevel(logging.INFO)
+
+        stream_handler = logging.StreamHandler()
+        stream_handler.setLevel(logging.INFO)
+
+        self.logger = logging.getLogger(log_name)
+        self.logger.setLevel(logging.INFO)
+        self.logger.addHandler(file_handler)
+        self.logger.addHandler(stream_handler)
+
+        # Setup parallel execution limit
+        self.cpu_limit = min(cpu_limit, multiprocessing.cpu_count())
+        self.semaphore = multiprocessing.BoundedSemaphore(self.cpu_limit)
 
     def run(self):
         """
-            This method starts the logging and the execution of experiments.
+        Runs all experiments.
         """
-        # logging process
-        logging_process = multiprocessing.Process(target=self.gather_output, args=(self.out_queue,))
-        logging_process.start()
 
         jobs = []
 
-        # start experiment jobs
         for exp in self.experiments:
-            job = multiprocessing.Process(target=exp.execute, args=(self.out_queue, self.semaphore,))
-            # is required to cap the amount of running experiments
-            self.semaphore.acquire()
+
+            # define experiment process
+            def run_experiment(semaphore):
+                exp.execute()  # run the actual experiment
+                semaphore.release()  # release CPU
+
+            job = multiprocessing.Process(
+                target=run_experiment,
+                args=(self.semaphore,)
+            )
+
+            # run experiment
+            self.semaphore.acquire()  # wait for a free CPU
             job.start()
+
+            # keep a list of all jobs
             jobs.append(job)
 
         # wait for all processes to be finished
         for job in jobs:
             job.join()
 
-        # signal the output thread to be done
-        self.out_queue.put(Experimenter.FINISHED)
-
-        # wait for the master process to be done
-        logging_process.join()

--- a/pypuf/tools.py
+++ b/pypuf/tools.py
@@ -136,27 +136,3 @@ class TrainingSet():
         self.challenges = array(list(sample_inputs(instance.n, N)))
         self.responses = instance.eval(self.challenges)
         self.N = N
-
-
-def setup_logger(logger_name, log_file="log", level=logging.INFO, write_file=True, write_console=True):
-    """
-        This function creates a logger, that can be used to log messages on stderr and/or a file.
-    :param logger_name: string name which should be used to get the  correct logger instance
-    :param log_file: file path to the log file
-    :param level: debug level default logging.INFO
-    :param write_file: if set to false the logger does not log to a file
-    :param write_console: if set to false the logger does not log to stderr
-    """
-    l = logging.getLogger(logger_name)
-    formatter = logging.Formatter('%(asctime)s : %(message)s')
-    if write_file:
-        file_handler = logging.FileHandler(log_file, mode='w')
-        file_handler.setFormatter(formatter)
-        l.addHandler(file_handler)
-
-    if write_console:
-        stream_handler = logging.StreamHandler()
-        stream_handler.setFormatter(formatter)
-        l.addHandler(stream_handler)
-
-    l.setLevel(level)

--- a/test/test_experiment_logistic_regression.py
+++ b/test/test_experiment_logistic_regression.py
@@ -4,13 +4,7 @@ from pypuf.experiments.experiment.logistic_regression import ExperimentLogisticR
 
 
 class TestExperimentLogisticRegression(unittest.TestCase):
-    def setUp(self):
+    def test_run_and_analyze(self):
         self.lr16_4 = ExperimentLogisticRegression('exp1.log', 8, 2, 2**8, 0xbeef, 0xbeef, LTFArray.transform_id,
-                                                   LTFArray.combiner_xor, restarts=6)
-        self.lr16_4.analysis()
-
-    def test_lr_experiment_output_string(self):
-        self.assertNotEqual(self.lr16_4.output_string(), '')
-
-    def test_lr_experiment_name(self):
-        self.assertNotEqual(self.lr16_4.name, '')
+                                                   LTFArray.combiner_xor)
+        self.lr16_4.execute()

--- a/test/test_experimenter.py
+++ b/test/test_experimenter.py
@@ -7,15 +7,15 @@ from pypuf.experiments.experimenter import Experimenter
 class TestExperimenter(unittest.TestCase):
     def test_lr_experiments(self):
         lr16_4_1 = ExperimentLogisticRegression('exp1.log', 8, 2, 2**8, 0xbeef, 0xbeef, LTFArray.transform_id,
-                                                LTFArray.combiner_xor, restarts=6)
+                                                LTFArray.combiner_xor)
         lr16_4_2 = ExperimentLogisticRegression('exp2.log', 8, 2, 2**8, 0xbeef, 0xbeef, LTFArray.transform_id,
-                                                LTFArray.combiner_xor, restarts=6)
+                                                LTFArray.combiner_xor)
         lr16_4_3 = ExperimentLogisticRegression('exp3.log', 8, 2, 2**8, 0xbeef, 0xbeef, LTFArray.transform_id,
-                                                LTFArray.combiner_xor, restarts=6)
+                                                LTFArray.combiner_xor)
         lr16_4_4 = ExperimentLogisticRegression('exp4.log', 8, 2, 2**8, 0xbeef, 0xbeef, LTFArray.transform_id,
-                                                LTFArray.combiner_xor, restarts=6)
+                                                LTFArray.combiner_xor)
         lr16_4_5 = ExperimentLogisticRegression('exp5.log', 8, 2, 2**8, 0xbeef, 0xbeef, LTFArray.transform_id,
-                                                LTFArray.combiner_xor, restarts=6)
+                                                LTFArray.combiner_xor)
         experiments = [lr16_4_1, lr16_4_2, lr16_4_3, lr16_4_4, lr16_4_5]
         experimenter = Experimenter('log', experiments)
         experimenter.run()

--- a/test/test_sim_learn.py
+++ b/test/test_sim_learn.py
@@ -4,39 +4,39 @@ import sim_learn
 
 class TestSimLearn(unittest.TestCase):
     def test_id(self):
-        sim_learn.main(["sim_learn", "16", "2", "id", "xor", "12000", "1", "2", "1234", "1234"])
+        sim_learn.main(["sim_learn", "8", "2", "id", "xor", "20", "1", "2", "1234", "1234"])
 
     def test_atf(self):
-        sim_learn.main(["sim_learn", "16", "2", "atf", "xor", "12000", "1", "2", "1234", "1234"])
+        sim_learn.main(["sim_learn", "8", "2", "atf", "xor", "20", "1", "2", "1234", "1234"])
 
     def test_mm(self):
-        sim_learn.main(["sim_learn", "16", "2", "mm", "xor", "12000", "1", "2", "1234", "1234"])
+        sim_learn.main(["sim_learn", "8", "2", "mm", "xor", "20", "1", "2", "1234", "1234"])
 
     def test_lightweight_secure(self):
-        sim_learn.main(["sim_learn", "16", "2", "lightweight_secure", "xor", "12000", "1", "2", "1234", "1234"])
+        sim_learn.main(["sim_learn", "8", "2", "lightweight_secure", "xor", "20", "1", "2", "1234", "1234"])
 
     def test_1_n_bent(self):
-        sim_learn.main(["sim_learn", "16", "2", "1_n_bent", "xor", "12000", "1", "2", "1234", "1234"])
+        sim_learn.main(["sim_learn", "8", "2", "1_n_bent", "xor", "20", "1", "2", "1234", "1234"])
 
     def test_1_1_bent(self):
-        sim_learn.main(["sim_learn", "16", "2", "1_1_bent", "xor", "12000", "1", "2", "1234", "1234"])
+        sim_learn.main(["sim_learn", "8", "2", "1_1_bent", "xor", "20", "1", "2", "1234", "1234"])
 
     def test_ip_mod2_id(self):
-        sim_learn.main(["sim_learn", "16", "2", "id", "ip_mod2", "12000", "1", "2", "1234", "1234"])
+        sim_learn.main(["sim_learn", "8", "2", "id", "ip_mod2", "20", "1", "2", "1234", "1234"])
 
     def test_ip_mod2_atf(self):
-        sim_learn.main(["sim_learn", "16", "2", "atf", "ip_mod2", "12000", "1", "2", "1234", "1234"])
+        sim_learn.main(["sim_learn", "8", "2", "atf", "ip_mod2", "20", "1", "2", "1234", "1234"])
 
     def test_ip_mod2_mm(self):
-        sim_learn.main(["sim_learn", "16", "2", "mm", "ip_mod2", "12000", "1", "2", "1234", "1234"])
+        sim_learn.main(["sim_learn", "8", "2", "mm", "ip_mod2", "20", "1", "2", "1234", "1234"])
 
     def test_ip_mod2_lightweight_secure(self):
-        sim_learn.main(["sim_learn", "16", "2", "lightweight_secure", "ip_mod2", "12000", "1", "2", "1234", "1234"])
+        sim_learn.main(["sim_learn", "8", "2", "lightweight_secure", "ip_mod2", "20", "1", "2", "1234", "1234"])
 
     def test_ip_mod2_1_n_bent(self):
-        sim_learn.main(["sim_learn", "16", "2", "1_n_bent", "ip_mod2", "12000", "1", "2", "1234", "1234"])
+        sim_learn.main(["sim_learn", "8", "2", "1_n_bent", "ip_mod2", "20", "1", "2", "1234", "1234"])
 
     def test_ip_mod2_1_1_bent(self):
-        sim_learn.main(["sim_learn", "16", "2", "1_1_bent", "ip_mod2", "12000", "1", "2", "1234", "1234"])
+        sim_learn.main(["sim_learn", "8", "2", "1_1_bent", "ip_mod2", "20", "1", "2", "1234", "1234"])
 
 


### PR DESCRIPTION
Main Contribution:
- Output of Experiment now relies only on python logging
- Experimenter organizes all results in single file with the result logger
- Experiment creates an exclusive logfile for progress logging
- Logistic Regression outputs weights for each step on DEBUG log level to
  progress logger
- Logistic Regression outputs result on INFO log level to result logger
- Semaphore logic is now moved to Experimenter entirely

Just because the tests are so annoying if not fixed:
- decreased run time for `sim_learn` tests to a couple of seconds