### PR TITLE
Adds the original lightweight secure transform from Majzoobi

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ The simulation currently consists of just one very broad class, the LTF Array Si
  * `id`: use the generated challenge directly as input to the LTF (note that this *does not* correspond to the physical implementation of Arbiter PUFs)
  * `atf`: use *Arbiter Threshold Functions*, that is, transform the challenges in a way such that we simulate physical implementations of Arbiter PUFs
  * `mm`: experimental input transformation with long PTF representation
- * `lightweight_secure`: input transformation as defined by Majzoobi et al. in [Lightweight Secure PUFs](http://aceslab.org/sites/default/files/Lightweight%20Secure%20PUFs_0.pdf)
- * `shift_lightweight_secure`: as defined by Majzoobi et al., but with the shift operation executed first.
+ * `lightweight_secure_original`: input transformation as defined by Majzoobi et al. in [Lightweight Secure PUFs](http://aceslab.org/sites/default/files/Lightweight%20Secure%20PUFs_0.pdf) 
+ * `lightweight_secure`: (DEPRECATED) Input transform as defined by Majzoobi et al. 2008, but with the shift operation executed after and without ATF transform.
+ * `shift_lightweight_secure`: (DEPRECATED) Input transform as defined by Majzoobi et al. 2008, with the shift operation executed first and without ATF transform.
  * `soelter_lightweight_secure`: as defined by Majzoobi et al., but with a one-bit modification due to Sölter.
  * `polynomial`: challenges are interpreted as polynomials from GF(2^n). From the initial challenge c the i-th Arbiter chain gets the coefficients of the polynomial c^(i+1) as challenge. For now only challenges with length 8, 16, 24, 32, 48, 64 are accepted.
  * `permutation_atf`: for each Arbiter chain first a pseudorandom permutation is applied and thereafter the ATF transform.

--- a/pypuf/simulation/arbiter_based/ltfarray.py
+++ b/pypuf/simulation/arbiter_based/ltfarray.py
@@ -88,7 +88,35 @@ class LTFArray(Simulation):
         return result
 
     @staticmethod
+    def transform_lightweight_secure_original(cs, k):
+        """
+        Input transform as defined by Majzoobi et al. 2008.
+        """
+        N = len(cs)
+        n = len(cs[0])
+        assert n % 2 == 0, 'Secure Lightweight Input Transformation only defined for even n. Sorry!'
+
+        cs_shift_trans = __class__.transform_shift_lightweight_secure(cs, k)
+
+        """ Perform atf transform """
+        result = transpose(
+            array([
+                prod(cs_shift_trans[:, :, i:], 2)
+                for i in range(n)
+            ]),
+            (1, 2, 0)
+        )
+
+        assert result.shape == (N, k, n), 'The resulting challenges have not the desired shape. Sorry!'
+
+        return result
+
+    @staticmethod
     def transform_lightweight_secure(cs, k):
+        """
+        Input transform as defined by Majzoobi et al. 2008, but with the shift
+        operation executed after and without ATF transform.
+        """
         N = len(cs)
         n = len(cs[0])
         assert n % 2 == 0, 'Secure Lightweight Input Transformation only defined for even n. Sorry!'
@@ -110,8 +138,8 @@ class LTFArray(Simulation):
     @staticmethod
     def transform_shift_lightweight_secure(cs, k):
         """
-        Input transform as defined by Majzoobi et al. 2008, but with the shift
-        operation executed first.
+        Input transform as defined by Majzoobi et al. 2008, with the shift
+        operation executed first and without ATF transform.
         """
         N = len(cs)
         n = len(cs[0])

--- a/test/test_sim_learn.py
+++ b/test/test_sim_learn.py
@@ -15,6 +15,9 @@ class TestSimLearn(unittest.TestCase):
     def test_lightweight_secure(self):
         sim_learn.main(["sim_learn", "8", "2", "lightweight_secure", "xor", "20", "1", "2", "1234", "1234"])
 
+    def test_lightweight_secure_original(self):
+        sim_learn.main(["sim_learn", "8", "2", "lightweight_secure_original", "xor", "20", "1", "2", "1234", "1234"])
+
     def test_1_n_bent(self):
         sim_learn.main(["sim_learn", "8", "2", "1_n_bent", "xor", "20", "1", "2", "1234", "1234"])
 


### PR DESCRIPTION
The new transform is now implemented in `transform_lightweight_secure_original`. It consists of three steps:

1. Shift
2. Input Network
3. ATF Transform

Currently only the following transformations where implemented:

1. `transform_lightweight_secure` which performs the following steps:
- Input Network
- Shift

2. `transform_shift_lightweight_secure` which performs the following steps:
- Shift
- Input Network

In both cases no ATF transform was applied.