### PR TITLE
Added 'stack' input transform to LTFArray

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The simulation currently consists of just one very broad class, the LTF Array Si
 
  `LTFArray` also implements "meta input transformations" that can be used to build a new input transformation from existing ones.
  * `concat(transform_1, nn, transform_2)`: the first `nn` bit will be transformed using `transform_1`, the rest will be transformed with `transform_2`. 
+ * `stack(transform_1, kk, transform_2)`: the first `kk` challenges will be transformed using `transform_1`, the rest will be transformed with `transform_2`.
 
 #### Combiner Function
 

--- a/pypuf/simulation/arbiter_based/ltfarray.py
+++ b/pypuf/simulation/arbiter_based/ltfarray.py
@@ -366,6 +366,36 @@ class LTFArray(Simulation):
         return result
 
     @staticmethod
+    def transform_stack(transform_1, kk, transform_2):
+        """
+        This input transformation will transform the first kk challenges using transform_1,
+        the remaining k - kk challenges using transform_2.
+        :return: A function that can perform the desired transformation
+        """
+        def transform(cs, k):
+            (N,n) = cs.shape
+            transformed_1 = transform_1(cs, kk)
+            transformed_2 = transform_2(cs, k - kk)
+            assert transformed_1.shape == (N, kk, n)
+            assert transformed_2.shape == (N, k - kk, n)
+            return concatenate(
+                (
+                    transformed_1,
+                    transformed_2,
+                ),
+                axis=1
+            )
+
+        transform.__name__ = 'transform_stack_%s_nn%i_%s' % \
+                             (
+                                 transform_1.__name__.replace('transform_', ''),
+                                 kk,
+                                 transform_2.__name__.replace('transform_', '')
+                             )
+
+        return transform
+
+    @staticmethod
     def transform_concat(transform_1, nn, transform_2):
         """
         This input transformation will transform the first nn bit of each challenge using transform_1,

--- a/test/test_simulation.py
+++ b/test/test_simulation.py
@@ -256,6 +256,33 @@ class TestInputTransformation(unittest.TestCase):
             ]
         )
 
+    def test_transform_stack(self):
+        test_array = array([
+            [1, -1, 1, -1],
+            [-1, -1, 1, -1],
+        ])
+        assert_array_equal(
+            LTFArray.transform_stack(
+                transform_1=LTFArray.transform_id,
+                kk=2,
+                transform_2=LTFArray.transform_shift
+            )(test_array, k=4),
+            [
+                [
+                    [1, -1, 1, -1],
+                    [1, -1, 1, -1],
+                    [1, -1, 1, -1],
+                    [-1, 1, -1, 1],
+                ],
+                [
+                    [-1, -1, 1, -1],
+                    [-1, -1, 1, -1],
+                    [-1, -1, 1, -1],
+                    [-1, 1, -1, -1],
+                ],
+            ]
+        )
+
     def test_transform_concat(self):
         test_array = array([
             [ 1, -1, -1,  1, -1,  1, -1,  1,  1, -1, -1],


### PR DESCRIPTION
This enables the user to use different input transforms for two (and, recursively, even more) partitions of the arbiter lines.