### PR TITLE
Fix experimenter deadlock

### DIFF
--- a/pypuf/experiments/experimenter.py
+++ b/pypuf/experiments/experimenter.py
@@ -41,8 +41,12 @@ class Experimenter(object):
 
             # define experiment process
             def run_experiment(queue, semaphore, logger_name):
-                exp.execute(queue, logger_name)  # run the actual experiment
-                semaphore.release()  # release CPU
+                try:
+                    exp.execute(queue, logger_name)  # run the actual experiment
+                    semaphore.release()  # release CPU
+                except Exception as e:
+                    semaphore.release()  # release CPU
+                    raise e
 
             job = multiprocessing.Process(
                 target=run_experiment,

--- a/pypuf/experiments/experimenter.py
+++ b/pypuf/experiments/experimenter.py
@@ -35,7 +35,8 @@ class Experimenter(object):
                                            args=(queue, setup_logger, self.logger_name,))
         listener.start()
 
-        jobs = []
+        # list of active jobs
+        active_jobs = []
 
         for exp in self.experiments:
 
@@ -53,15 +54,28 @@ class Experimenter(object):
                 args=(queue, self.semaphore, self.logger_name)
             )
 
-            # run experiment
-            self.semaphore.acquire()  # wait for a free CPU
-            job.start()
+            # wait for a free CPU
+            self.semaphore.acquire()
 
-            # keep a list of all jobs
-            jobs.append(job)
+            def list_active_jobs():
+                """
+                update list of active jobs
+                return: [multiprocessing.Process] list of active jobs
+                """
+                still_active_jobs = []
+                for j in active_jobs:
+                    j.join(0)
+                    if j.exitcode is None:
+                        still_active_jobs.append(j)
+                return still_active_jobs
+
+            # start experiment
+            job.start()
+            active_jobs = list_active_jobs()
+            active_jobs.append(job)
 
         # wait for all processes to be finished
-        for job in jobs:
+        for job in active_jobs:
             job.join()
 
         # Quit logging process

--- a/pypuf/experiments/experimenter.py
+++ b/pypuf/experiments/experimenter.py
@@ -90,11 +90,7 @@ def setup_logger(logger_name):
     file_handler = logging.FileHandler(filename='%s.log' % logger_name, mode='w')
     file_handler.setLevel(logging.INFO)
 
-    stream_handler = logging.StreamHandler()
-    stream_handler.setLevel(logging.INFO)
-
     root.addHandler(file_handler)
-    root.addHandler(stream_handler)
 
 
 def log_listener(queue, configurer, logger_name):

--- a/test/test_experimenter.py
+++ b/test/test_experimenter.py
@@ -2,6 +2,7 @@ import unittest
 import os
 import glob
 from pypuf.simulation.arbiter_based.ltfarray import LTFArray
+from pypuf.experiments.experiment.base import Experiment
 from pypuf.experiments.experiment.logistic_regression import ExperimentLogisticRegression
 from pypuf.experiments.experimenter import Experimenter
 
@@ -76,3 +77,27 @@ class TestExperimenter(unittest.TestCase):
         log_file = open('test_multiprocessing_logs.log', 'r')
         self.assertEqual(line_count(log_file), n, 'Unexpected number of results')
         log_file.close()
+
+    def test_file_handle(self):
+        """
+        This test check if process file handles are deleted. Some Systems have have limit of open file handles. 
+        :return: 
+        """
+        class ExperimentDummy(Experiment):
+            def __init__(self, log_name):
+                super().__init__(log_name)
+
+            def run(self):
+                pass
+
+            def analyze(self):
+                pass
+
+        experiments = []
+        n = 1024
+        for i in range(n):
+            log_name = 'fail{0}'.format(i)
+            experiments.append(ExperimentDummy(log_name))
+
+        experimenter = Experimenter('fail', experiments)
+        experimenter.run()


### PR DESCRIPTION
This PR fixes the deadlock which occurred when schedule more than ~1000 experiments. This was necessary because the process handles were never released. There is also no use to print all results to stdout so i removed it.