### PR TITLE
Pseudorandom Permutation Input Transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The simulation currently consists of just one very broad class, the LTF Array Si
 
  `LTFArray` also implements "meta input transformations" that can be used to build a new input transformation from existing ones.
  * `concat(transform_1, nn, transform_2)`: the first `nn` bit will be transformed using `transform_1`, the rest will be transformed with `transform_2`. 
+ * `permutations(seed, nn, kk, atf)`: each of the `kk` LTFs will be fed a random, but fixed permutation generated based on the given seed. If `atf`, then challenges will be ATF-transformed after permuting them.
  * `stack(transform_1, kk, transform_2)`: the first `kk` challenges will be transformed using `transform_1`, the rest will be transformed with `transform_2`.
 
 #### Combiner Function

--- a/pypuf/simulation/arbiter_based/ltfarray.py
+++ b/pypuf/simulation/arbiter_based/ltfarray.py
@@ -368,7 +368,7 @@ class LTFArray(Simulation):
     @staticmethod
     def transform_stack(transform_1, kk, transform_2):
         """
-        This input transformation will transform the first kk challenges using transform_1,
+        Returns an input transformation that will transform the first kk challenges using transform_1,
         the remaining k - kk challenges using transform_2.
         :return: A function that can perform the desired transformation
         """
@@ -398,7 +398,7 @@ class LTFArray(Simulation):
     @staticmethod
     def transform_concat(transform_1, nn, transform_2):
         """
-        This input transformation will transform the first nn bit of each challenge using transform_1,
+        Returns an input transformation that will transform the first nn bit of each challenge using transform_1,
         the remaining bits using transform_2.
         :return: A function that can perform the desired transformation
         """

--- a/test/test_simulation.py
+++ b/test/test_simulation.py
@@ -283,6 +283,51 @@ class TestInputTransformation(unittest.TestCase):
             ]
         )
 
+    def test_transform_permutations(self):
+        test_array = array([
+            [1,2,3,4],
+            [10,20,30,40],
+        ])
+        assert_array_equal(
+            LTFArray.transform_permutations(
+                seed=0xbeef,
+                nn=4,
+                kk=3,
+            )(test_array, k=3),
+            [
+                [
+                    [4, 1, 2, 3],
+                    [1, 4, 3, 2],
+                    [3, 1, 4, 2],
+                ],
+                [
+                    [40, 10, 20, 30],
+                    [10, 40, 30, 20],
+                    [30, 10, 40, 20],
+                ],
+            ],
+        )
+        assert_array_equal(
+            LTFArray.transform_permutations(
+                seed=0xbeef,
+                nn=4,
+                kk=3,
+                atf=True,
+            )(test_array, k=3),
+            [
+                [
+                    [4*1*2*3, 1*2*3, 2*3, 3],
+                    [1*4*3*2, 4*3*2, 3*2, 2],
+                    [3*1*4*2, 1*4*2, 4*2, 2],
+                ],
+                [
+                    [40*10*20*30, 10*20*30, 20*30, 30],
+                    [10*40*30*20, 40*30*20, 30*20, 20],
+                    [30*10*40*20, 10*40*20, 40*20, 20],
+                ],
+            ],
+        )
+
     def test_transform_concat(self):
         test_array = array([
             [ 1, -1, -1,  1, -1,  1, -1,  1,  1, -1, -1],


### PR DESCRIPTION
Adds an input transform based on pseudorandom permutations, one for each LTF in the LTFArray.

This should be merged into master after #49 is resolved.