### PR TITLE
Feature majority ltf

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ Another component of the simulation is the Fourier expansion of a Boolean functi
  * `random`: Each Arbiter chain gets a random challenge derived from the original challenge using a PRNG.
 
  `LTFArray` also implements "meta input transformations" that can be used to build a new input transformation from existing ones.
- * `concat(transform_1, nn, transform_2)`: the first `nn` bit will be transformed using `transform_1`, the rest will be transformed with `transform_2`. 
- * `permutations(seed, nn, kk, atf)`: each of the `kk` LTFs will be fed a random, but fixed permutation generated based on the given seed. If `atf`, then challenges will be ATF-transformed after permuting them.
- * `stack(transform_1, kk, transform_2)`: the first `kk` challenges will be transformed using `transform_1`, the rest will be transformed with `transform_2`.
+ * `generate_concatenated_transform(transform_1, nn, transform_2)`: the first `nn` bit will be transformed using `transform_1`, the rest will be transformed with `transform_2`. 
+ * `generate_random_permutation_transform(seed, nn, kk, atf)`: each of the `kk` LTFs will be fed a random, but fixed permutation generated based on the given seed. If `atf`, then challenges will be ATF-transformed after permuting them.
+ * `generate_stacked_transform(transform_1, kk, transform_2)`: the first `kk` challenges will be transformed using `transform_1`, the rest will be transformed with `transform_2`.
 
 #### Combiner Function
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Note that pypuf uses the {-1,1} notation of bits, where True = -1 and False = +1
 
 ### Simulation
 
-The simulation currently consists of a very broad class, the LTF Array Simulator. It can simulate an array of Linear Threshold Functions and hence simulate [Arbiter PUFs](https://people.csail.mit.edu/devadas/pubs/cpuf-journal.pdf), XOR Arbiter PUFs, [Lightweight Secure PUFs](http://aceslab.org/sites/default/files/Lightweight%20Secure%20PUFs_0.pdf), and more custom designs. To that end, the input transformation can be chosen (e.g. as designed for the Lightweight Secure PUF) and the combiner function can be chosen (to generalize the usually used XOR function).  
+The simulation currently consists of a very broad class, the LTF Array Simulator. It can simulate an array of Linear Threshold Functions and hence simulate [Arbiter PUFs](https://people.csail.mit.edu/devadas/pubs/cpuf-journal.pdf), XOR Arbiter PUFs, [Lightweight Secure PUFs](http://aceslab.org/sites/default/files/Lightweight%20Secure%20PUFs_0.pdf), Majority Vote PUFs, and more custom designs. To that end, the input transformation can be chosen (e.g. as designed for the Lightweight Secure PUF) and the combiner function can be chosen (to generalize the usually used XOR function).  
 Another component of the simulation is the Fourier expansion of a Boolean function. It either can be evaluated returning a real value or boxed into the sign operator, returning -1 or +1.
 
 #### Input Transformation

--- a/pypuf/simulation/arbiter_based/ltfarray.py
+++ b/pypuf/simulation/arbiter_based/ltfarray.py
@@ -557,5 +557,6 @@ class NoisyLTFArray(LTFArray):
         Random numbers are drawn from the PRNG instance generated when
         initializing the NoisyLTFArray.
         """
-        noise = self.random.normal(loc=0, scale=self.sigma_noise, size=(1, self.k))
-        return super().ltf_eval(inputs) + noise
+        evaled_inputs = super().ltf_eval(inputs)
+        noise = self.random.normal(loc=0, scale=self.sigma_noise, size=(len(evaled_inputs), self.k))
+        return evaled_inputs + noise

--- a/pypuf/simulation/arbiter_based/ltfarray.py
+++ b/pypuf/simulation/arbiter_based/ltfarray.py
@@ -367,7 +367,7 @@ class LTFArray(Simulation):
         return result
 
     @staticmethod
-    def transform_stack(transform_1, kk, transform_2):
+    def generate_stacked_transform(transform_1, kk, transform_2):
         """
         Returns an input transformation that will transform the first kk challenges using transform_1,
         the remaining k - kk challenges using transform_2.
@@ -397,7 +397,7 @@ class LTFArray(Simulation):
         return transform
 
     @staticmethod
-    def transform_permutations(seed, nn, kk, atf=False):
+    def generate_random_permutation_transform(seed, nn, kk, atf=False):
         """
         Returns an input transformation that uses k pseudorandomly generated permutations
         :param seed: Seed for the pseudorandom generation
@@ -439,7 +439,7 @@ class LTFArray(Simulation):
         return transform
 
     @staticmethod
-    def transform_concat(transform_1, nn, transform_2):
+    def generate_concatenated_transform(transform_1, nn, transform_2):
         """
         Returns an input transformation that will transform the first nn bit of each challenge using transform_1,
         the remaining bits using transform_2.

--- a/pypuf/tools.py
+++ b/pypuf/tools.py
@@ -32,14 +32,14 @@ def random_inputs(n, num, random_instance=RandomState()):
         yield random_input(n, random_instance)
 
 
-def sample_inputs(n, num):
+def sample_inputs(n, num, random_instance=RandomState()):
     """
     returns an iterator for either random samples of {-1,1}-vectors of length `n` if `num` < 2^n,
     and an iterator for all {-1,1}-vectors of length `n` otherwise.
     Note that we return only 2^n vectors even with `num` > 2^n.
     In other words, the output of this function is deterministic if and only if num >= 2^n.
     """
-    return random_inputs(n, num) if num < 2 ** n else all_inputs(n)
+    return random_inputs(n, num, random_instance) if num < 2 ** n else all_inputs(n)
 
 
 def iter_append_last(array_iterator, x):
@@ -50,7 +50,7 @@ def iter_append_last(array_iterator, x):
         yield append(array, x)
 
 
-def approx_dist(a, b, num):
+def approx_dist(a, b, num, random_instance=RandomState()):
     """
     Approximate the distance of two functions a, b by evaluating a random set of inputs.
     a, b needs to have eval() method and input_length member.
@@ -58,7 +58,7 @@ def approx_dist(a, b, num):
     """
     assert a.n == b.n
     d = 0
-    inputs = array(list(random_inputs(a.n, num)))
+    inputs = array(list(random_inputs(a.n, num, random_instance)))
     return (num - count_nonzero(a.eval(inputs) == b.eval(inputs))) / num
 
 

--- a/test/test_simulation.py
+++ b/test/test_simulation.py
@@ -577,7 +577,9 @@ class TestNoisyLTFArray(TestLTFArray):
                 random_instance=noise_prng_1,
             )
 
+            evaled_ltf_array = ltf_array.ltf_eval(transformed_inputs)
             assert_array_equal(
-                around(ltf_array.ltf_eval(transformed_inputs) + noise_prng_2.normal(size=(1, k)), decimals=10),
+                around(evaled_ltf_array + noise_prng_2.normal(loc=0, scale=1,
+                                                               size=(len(evaled_ltf_array), k)), decimals=10),
                 around(noisy_ltf_array.ltf_eval(transformed_inputs), decimals=10)
             )

--- a/test/test_simulation.py
+++ b/test/test_simulation.py
@@ -262,7 +262,7 @@ class TestInputTransformation(unittest.TestCase):
             [-1, -1, 1, -1],
         ])
         assert_array_equal(
-            LTFArray.transform_stack(
+            LTFArray.generate_stacked_transform(
                 transform_1=LTFArray.transform_id,
                 kk=2,
                 transform_2=LTFArray.transform_shift
@@ -289,7 +289,7 @@ class TestInputTransformation(unittest.TestCase):
             [10,20,30,40],
         ])
         assert_array_equal(
-            LTFArray.transform_permutations(
+            LTFArray.generate_random_permutation_transform(
                 seed=0xbeef,
                 nn=4,
                 kk=3,
@@ -308,7 +308,7 @@ class TestInputTransformation(unittest.TestCase):
             ],
         )
         assert_array_equal(
-            LTFArray.transform_permutations(
+            LTFArray.generate_random_permutation_transform(
                 seed=0xbeef,
                 nn=4,
                 kk=3,
@@ -333,7 +333,7 @@ class TestInputTransformation(unittest.TestCase):
             [ 1, -1, -1,  1, -1,  1, -1,  1,  1, -1, -1],
         ])
         assert_array_equal(
-            LTFArray.transform_concat(
+            LTFArray.generate_concatenated_transform(
                 transform_1=LTFArray.transform_1_n_bent,
                 nn=6,
                 transform_2=LTFArray.transform_id,


### PR DESCRIPTION
This pr implements a ltf array majority vote arbiter puf.

This pr implements a majority vote puf based on the LTFArray class.
I refactored NoisyLTFArray because it adds the same noise on each challenge https://github.com/nils-wisiol/pypuf/blob/feature_majority_ltf/pypuf/simulation/arbiter_based/ltfarray.py#L561-L562 . If this behavior is desired I will change my code in order to use the NoisyLTFArray.