### PR TITLE
Refactor sim_learn for parallel execution

### DIFF
--- a/sim_learn.py
+++ b/sim_learn.py
@@ -1,18 +1,15 @@
-from numpy import amin, amax, mean, array, append
-from numpy.random import RandomState
-from pypuf.learner.regression.logistic_regression import LogisticRegression
 from pypuf.simulation.arbiter_based.ltfarray import LTFArray
-from pypuf import tools
-import time
-from sys import argv, stdout, stderr
+from pypuf.experiments.experiment.logistic_regression import ExperimentLogisticRegression
+from pypuf.experiments.experimenter import Experimenter
+from sys import argv, stderr
 
 
 def main(args):
 
-    if len(args) != 10:
+    if len(args) < 10 or len(args) > 11:
         stderr.write('LTF Array Simulator and Logistic Regression Learner\n')
         stderr.write('Usage:\n')
-        stderr.write('sim_learn.py n k transformation combiner N restarts seed_instance seed_model\n')
+        stderr.write('sim_learn.py n k transformation combiner N restarts seed_instance seed_model [log_name]\n')
         stderr.write('               n: number of bits per Arbiter chain\n')
         stderr.write('               k: number of Arbiter chains\n')
         stderr.write('  transformation: used to transform input before it is used in LTFs\n')
@@ -56,6 +53,8 @@ def main(args):
         stderr.write('                  The number total learning attempts is restarts*instances.\n')
         stderr.write('   seed_instance: random seed used for LTF array instance\n')
         stderr.write('      seed_model: random seed used for the model in first learning attempt\n')
+        stderr.write('      [log_name]: path to the logfile which contains results from all instances. The tool '
+                                        'will add a ".log" to log_name. The default path is ./sim_learn.log\n')
         quit(1)
 
     n = int(args[1])
@@ -76,10 +75,6 @@ def main(args):
     seed_instance = int(args[8], 16)
     seed_model = int(args[9], 16)
 
-    # reproduce 'random' numbers and avoid interference with other random numbers drawn
-    instance_prng = RandomState(seed=seed_instance)
-    model_prng = RandomState(seed=seed_model)
-
     transformation = None
     combiner = None
 
@@ -95,6 +90,10 @@ def main(args):
         stderr.write('Combiner %s unknown or currently not implemented\n' % combiner_name)
         quit()
 
+    log_name = 'sim_learn'
+    if len(args) == 11:
+        log_name = args[10]
+
     stderr.write('Learning %s-bit %s XOR Arbiter PUF with %s CRPs and %s restarts.\n\n' % (n, k, N, restarts))
     stderr.write('Using\n')
     stderr.write('  transformation:       %s\n' % transformation)
@@ -103,76 +102,48 @@ def main(args):
     stderr.write('  model random seed:    0x%x\n' % seed_model)
     stderr.write('\n')
 
-    accuracy = array([])
-    training_times = array([])
-    iterations = array([])
-
+    # create different experiment instances
+    experiments = []
     for j in range(instances):
-
-        stderr.write('----------- Choosing new instance. ---------\n')
-
-        instance = LTFArray(
-            weight_array=LTFArray.normal_weights(n, k, random_instance=instance_prng),
-            transform=transformation,
-            combiner=combiner,
-        )
-
-        lr_learner = LogisticRegression(
-            tools.TrainingSet(instance=instance, N=N),
-            n,
-            k,
+        l_name = log_name + str(j)
+        experiment = ExperimentLogisticRegression(
+            log_name=l_name,
+            n=n,
+            k=k,
+            N=N,
+            seed_instance=seed_instance + j,
+            seed_model=seed_model + j,
             transformation=transformation,
-            combiner=combiner,
-            weights_prng=model_prng,
+            combiner=combiner
         )
+        experiments.append(experiment)
 
-        i = 0
-        dist = 1
+    experimenter = Experimenter(log_name, experiments)
+    # run the instances
+    experimenter.run()
 
-        while i < restarts and 1 - dist < convergence:
-            stderr.write('\r%5i/%5i         ' % (i+1, restarts if restarts < float('inf') else 0))
-            start = time.time()
-            model = lr_learner.learn()
-            end = time.time()
-            training_times = append(training_times, end - start)
-            dist = tools.approx_dist(instance, model, min(10000, 2 ** n))
-            accuracy = append(accuracy, 1 - dist)
-            iterations = append(iterations, lr_learner.iteration_count)
-            # output test result in machine-friendly format
-            # seed_ltf seed_model idx_restart n k N transformation combiner iteration_count time accuracy
-            stderr.write(' '.join(
-                [
-                    '0x%x' % seed_instance,
-                    '0x%x' % seed_model,
-                    '%5d' % i,
-                    '%3d' % n,
-                    '%2d' % k,
-                    '%6d' % N,
-                    '%s' % transformation_name,
-                    '%s' % combiner_name,
-                    '%4d' % lr_learner.iteration_count,
-                    '%9.3f' % (end - start),
-                    '%1.5f' % (1 - dist),
-                ]
-            ) + '\n')
-            #stderr.write('training time:                % 5.3fs' % (end - start))
-            #stderr.write('min training distance:        % 5.3f' % lr_learner.min_distance)
-            #stderr.write('test distance (1000 samples): % 5.3f\n' % dist)
-            i += 1
+    # output format
+    str_format = '{:<15}\t{:<10}\t{:<8}\t{:<8}\t{:<8}\t{:<8}\t{:<18}\t{:<15}\t{:<6}\t{:<8}\t{:<8}\t{:<8}'
+    headline = str_format.format(
+        'seed_instance', 'seed_model', 'i', 'n', 'k', 'N', 'trans', 'comb', 'iter', 'time', 'accuracy',
+        'model_values\n'
+    )
+    # print the result headline
+    stderr.write(headline)
 
-    stderr.write('\r              \r')
-    stderr.write('\n\n')
-    stderr.write('training times: %s\n' % training_times)
-    stderr.write('iterations: %s\n' % iterations)
-    stderr.write('test accuracy: %s\n' % accuracy)
-    stderr.write('\n\n')
-    stderr.write('min/avg/max training time  : % 9.3fs /% 9.3fs /% 9.3fs\n' % (
-    amin(training_times), mean(training_times), amax(training_times)))
-    stderr.write('min/avg/max iteration count: % 9.3f  /% 9.3f  /% 9.3f \n' % (
-    amin(iterations), mean(iterations), amax(iterations)))
-    stderr.write(
-        'min/avg/max test accuracy  : % 9.3f  /% 9.3f  /% 9.3f \n' % (amin(accuracy), mean(accuracy), amax(accuracy)))
-    stderr.write('\n\n')
+    log_file = open(log_name + '.log', 'r')
+
+    # print the results
+    result = log_file.readline()
+    while result != '':
+        stderr.write(str_format.format(*result.split('\t')))
+        result = log_file.readline()
+
+    log_file.close()
+
+
+
+
 
 
 if __name__ == '__main__':

--- a/test/test_sim_learn.py
+++ b/test/test_sim_learn.py
@@ -1,8 +1,22 @@
 import unittest
+import os
+import glob
 import sim_learn
 
 
 class TestSimLearn(unittest.TestCase):
+    def setUp(self):
+        # Remove all log files
+        paths = list(glob.glob('*.log'))
+        for p in paths:
+            os.remove(p)
+
+    def tearDown(self):
+        # Remove all log files
+        paths = list(glob.glob('*.log'))
+        for p in paths:
+            os.remove(p)
+
     def test_id(self):
         sim_learn.main(["sim_learn", "8", "2", "id", "xor", "20", "1", "2", "1234", "1234"])
 
@@ -45,4 +59,22 @@ class TestSimLearn(unittest.TestCase):
     def test_permutation_atf(self):
         sim_learn.main(["sim_learn", "8", "2", "permutation_atf", "xor", "10", "1", "2", "1234", "1234"])
 
+    def test_log_name(self):
+        instance_count = 2
+        log_name = 'test_log'
+        sim_learn.main(["sim_learn", "8", "2", "id", "xor", "10", "1", str(instance_count), "1234", "1234", log_name])
 
+        def line_count(file_object):
+            """
+            :param file_object:
+            :return: number of lines
+            """
+            count = 0
+            while file_object.readline() != '':
+                count = count + 1
+            return count
+
+        # Check if the number of results is correct
+        log_file = open(log_name + '.log', 'r')
+        self.assertEqual(line_count(log_file), instance_count, 'Unexpected number of results')
+        log_file.close()


### PR DESCRIPTION
This PR adds the possibility to execute the logistic regression learning for multiple instances in parallel #6.
In oder to simplify the implementation this also changes the style of the result output.

An example:

```
Learning 16-bit 2 XOR Arbiter PUF with 12000 CRPs and 1 restarts.

Using
  transformation:       <function LTFArray.transform_id at 0x7f67ee5639d8>
  combiner:             <function LTFArray.combiner_xor at 0x7f67ee563598>
  instance random seed: 0x1234
  model random seed:    0x1234

seed_instance   seed_model i        n        k        N        trans        comb            iter   time     accuracy model_values
0x1234          0x1234     0        16       2        12000    transform_id combiner_xor    1      0.547883 0.752400 -0.103128302326,-0.294435984627,-0.2301045537,-0.092926424749,-0.0594743485947,-0.206606341856,0.103940075609,-0.0994102889547,-0.229579761635,-0.303942235814,0.0992602768466,0.0379148550194,0.142221330442,-0.0803966284407,-0.276831879412,0.114270728262,-0.200058893264,-0.152961510092,0.120841846591,-0.179512230363,-0.222761454582,0.0763456464573,0.108704463932,0.186765385242,-0.232071544657,0.0890390572844,0.124666760159,-0.1336616284,0.153237009713,-0.329391759828,0.171530012422,0.180067313365
0x1235          0x1235     0        16       2        12000    transform_id combiner_xor    1      0.552575 0.747500 -0.258518458561,-0.366108390184,-0.238520165525,0.227608661211,0.0290734108976,0.0650860177828,-0.256280399789,-0.192700356541,-0.0728825415534,-0.208113908759,0.118748168607,-0.0365836265003,0.126803302944,-0.160960596005,0.0922988335474,-0.207264284189,-0.347208656084,-0.0916392185632,-0.198108456511,0.0443499285184,-0.0929434864149,0.0306573003847,0.0238066808625,-0.0201916109313,-0.100996782275,-0.132552279966,-0.155540140846,-0.272258108352,0.231209806792,0.181266534536,-0.0537033519005,0.170315909381```
 