### PR TITLE
Feature pep8 linter regression

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,3 +1,7 @@
+[MASTER]
+# This is used in order to fix numpy false positives.
+extension-pkg-whitelist=numpy
+
 [MISCELLANEOUS]
 
 # List of note tags to take in consideration, separated by a comma.
@@ -7,24 +11,22 @@ notes=FIXME,XXX
 [BASIC]
 
 # Good variable names which should always be accepted, separated by a comma
-good-names=i,j,k,ex,Run,_,n,N
+good-names=i,j,k,ex,Run,_,n,N,mu
+
+# Naming hint for function names
+function-name-hint=(([a-z][a-z0-9_]{2,37})|(_[a-z0-9_]*))$
+
+# Regular expression matching correct function names
+function-rgx=(([a-z][a-z0-9_]{2,37})|(_[a-z0-9_]*))$
+
+# Naming hint for method names
+method-name-hint=(([a-z][a-z0-9_]{2,37})|(_[a-z0-9_]*))$
+
+# Regular expression matching correct method names
+method-rgx=(([a-z][a-z0-9_]{2,37})|(_[a-z0-9_]*))$
 
 
 [FORMAT]
 
 # Maximum number of characters on a single line.
 max-line-length=120
-
-
-[SIMILARITIES]
-
-# Minimum lines number of a similarity.
-min-similarity-lines=15
-
-[DESIGN]
-
-# Maximum number of arguments for function / method
-max-args=10
-
-# Maximum number of attributes for a class (see R0902).
-max-attributes=18

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,30 @@
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,XXX
+
+
+[BASIC]
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,j,k,ex,Run,_,n,N
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=120
+
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+min-similarity-lines=15
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=10
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=18

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ python:
   - "3.6"
 # command to install dependencies
 install: "pip install -r requirements.txt"
-# command to run tests
-script: python -m unittest
-
+script:
+  # command to run tests
+  - python -m unittest
+  # command to run python code check
+  - find . -name "*.py" -print0 | xargs -0 pylint --disable=R

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ script:
   # command to run tests
   - python -m unittest
   # command to run python code check
-  - find . -name "*.py" -print0 | xargs -0 pylint --disable=R
+  - python linter.py

--- a/linter.py
+++ b/linter.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""
+This command line tool is used to start the python code analysis. For this purpose it uses pep8 for coding conventions
+and pylint for extended issues.
+"""
+from sys import argv, executable
+from argparse import ArgumentParser
+from subprocess import run
+from fnmatch import filter as fn_filter
+from os import walk, path
+
+
+def main(arguments):
+    """
+    This method starts the execution of the code analysis on every python file of a given path.
+    :param arguments: [String, int]
+                 This may include the path to the current path to analyse and the maximal number of characters
+                 for each line of code.
+    """
+    parser = ArgumentParser(
+        usage='This tool can be used to check the python code in a directory on style\nviolations.'
+              'The scripts default path is the directory in which this script is\nlocated in.'
+    )
+    parser.add_argument(
+        '--path', help='a path to the directory where the python code should be analyzed '
+        '(default path os ".")', default='.', type=str, dest='path',
+    )
+    parser.add_argument(
+        '--max-line-length', help='maximal number of characters for each line (default is 120)',
+        default='120', type=int, dest='max_line_length',
+    )
+    args = parser.parse_args(arguments)
+
+    # set maximal line length
+    max_line_length = '--max-line-length={0}'.format(args.max_line_length)
+    # run pep8 check
+    run([executable, '-m', 'pep8', max_line_length, args.path])
+
+    # pylint does not support to check subdirectories by default
+    files_to_check = []
+    for root, _, file_names in walk(args.path):
+        for filename in fn_filter(file_names, '*.py'):
+            files_to_check.append(path.join(root, filename))
+
+    # if the path is a single file
+    if not files_to_check:
+        files_to_check = [args.path]
+
+    pylint_cmd = [executable, '-m', 'pylint', max_line_length, '--disable=R']
+    pylint_cmd.extend(files_to_check)
+    # run pylint check
+    run(pylint_cmd)
+
+
+if __name__ == '__main__':
+    main(argv[1:])

--- a/mv_num_of_votes.py
+++ b/mv_num_of_votes.py
@@ -1,22 +1,57 @@
+"""
+This module is a command line tool which provides the functionality to find the minimal number of votes which is
+needed in order to satisfy the desired stability of challenges and overall desired stability of responses of the
+SimulationMajorityLTFArray instance. The experiment is designed to find the number of votes for a range of k PUFs and
+a defined number of restarts.
+
+Example usage "python stab_c stab_all n k_max k_range s_ratio N restarts"
+
+stab_c: float
+        values: [0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95]
+        Desired stability of the challenges. The number which is used to decide whether a PUF is stable or not.
+stab_all: float
+          values: [0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95]
+          Overall desired stability. The relative frequency of challenges which are greater equal than the
+          desired_stability.
+n: int
+   values: [8, 16, 24, 32, 48, 64, 128]
+   Number of bits per Arbiter chain
+k_max: int
+       Maximum number of Arbiter chains
+k_range: int
+         Number of step size between the number of Arbiter chains
+s_ratio: float
+         The noisiness factor which is used to scale sigma_noise. The value sigma_noise
+         is the standard deviation of the noise distribution of the PUF instance simulation.
+N: int
+   values: range(10, 10001, 10)
+   The number of challenges which are used to evaluate the PUF.
+restarts: int
+          Number of restarts to the entire process
+"""
 from sys import stderr, argv
+import argparse
 from pypuf.experiments.experimenter import Experimenter
 from pypuf.experiments.experiment.majority_vote import ExperimentMajorityVoteFindVotes
-from pypuf.simulation.arbiter_based.ltfarray import LTFArray, NoisyLTFArray
-import argparse
+from pypuf.simulation.arbiter_based.ltfarray import LTFArray
+
 
 def main(args):
-
+    """
+    This method starts several experiments in order to find the minimal number of votes required to satisfy an
+    the desired stability of challenges.
+    """
     parser = argparse.ArgumentParser(usage="Experiment to determine the minimum number of votes "
                                            "required to achieve a desired given stability.\n")
-    parser.add_argument("stab_c", help="Desired stability of the challenges.", type=float,
-                        choices=[0.5,0.55,0.6,0.65,0.7,0.75,0.8,0.85,0.9,0.95])
-    parser.add_argument("stab_all", help="Overall desired stability.", type=float,
+    parser.add_argument("stab_c", help="Desired stability of the challenges", type=float,
                         choices=[0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95])
-    parser.add_argument("n", help="Number of bits per Arbiter chain.", type=int,
+    parser.add_argument("stab_all", help="Overall desired stability", type=float,
+                        choices=[0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95])
+    parser.add_argument("n", help="Number of bits per Arbiter chain", type=int,
                         choices=[8, 16, 24, 32, 48, 64, 128])
-    parser.add_argument("k_max", help="Maximum number of Arbiter chains.", type=int)
+    parser.add_argument("k_max", help="Maximum number of Arbiter chains", type=int)
     parser.add_argument("k_range", help="Number of step size between the number of Arbiter chains", type=int,
-                        choices=range(1,33))
+                        choices=range(1, 33))
     parser.add_argument("s_ratio", help="Ratio of standard deviation of the noise and weights", type=float)
     parser.add_argument("N", help="Number of challenges to evaluate", type=int, choices=range(10, 10001, 10))
     parser.add_argument("restarts", help="Number of restarts to the entire process", type=int)

--- a/pypuf/experiments/experiment/base.py
+++ b/pypuf/experiments/experiment/base.py
@@ -1,3 +1,7 @@
+"""
+This module provides an abstract class which can be used by a pypuf.experiments.experimenter.Experimenter object in
+order to be executed.
+"""
 import abc
 import time
 import logging
@@ -40,13 +44,15 @@ class Experiment(object):
         """
         raise NotImplementedError('users must define run() to use this base class')
 
-
-
     def execute(self, queue, logger_name):
         """
         Executes the experiment at hand by
         (1) calling run() and measuring the run time of run() and
         (2) calling analyze().
+        :param queue: multiprocessing.queue
+                      Multiprocessing safe queue which is used to serialize the logging
+        :param logger_name: string
+                        Name of the experimenter result logger
         """
         self.result_logger = setup_result_logger(queue, logger_name)
         file_handler = logging.FileHandler('%s.log' % self.log_name, mode='w')
@@ -57,12 +63,14 @@ class Experiment(object):
         self.measured_time = time.time() - start_time
         self.analyze()
 
+
 def setup_result_logger(queue, logger_name):
     """
     This method setups a connection to the experimenter result logger.
-    :param queue: Multiprocessing safe queue which is used to serialize the logging
-    :param logger_name: Name of the experimenter result logger
-    :return:
+    :param queue: multiprocessing.queue
+                  Multiprocessing safe queue which is used to serialize the logging
+    :param logger_name: string
+                        Name of the experimenter result logger
     """
     handler = logging.handlers.QueueHandler(queue)
     root = logging.getLogger(logger_name)

--- a/pypuf/experiments/experiment/logistic_regression.py
+++ b/pypuf/experiments/experiment/logistic_regression.py
@@ -1,5 +1,8 @@
+"""
+This module provides an experiment class which learns an instance of LTFArray simulation PUF with the logistic
+regression learner.
+"""
 from numpy.random import RandomState
-from numpy import amin, amax, mean, array, append
 from numpy.linalg import norm
 from pypuf.experiments.experiment.base import Experiment
 from pypuf.learner.regression.logistic_regression import LogisticRegression
@@ -9,10 +12,31 @@ from pypuf import tools
 
 class ExperimentLogisticRegression(Experiment):
     """
-        This Experiment uses the logistic regression learner on an LTFArray PUF simulation.
+    This Experiment uses the logistic regression learner on an LTFArray PUF simulation.
     """
 
     def __init__(self, log_name, n, k, N, seed_instance, seed_model, transformation, combiner):
+        """
+        :param log_name: string
+                         Prefix of the path or name of the experiment log file.
+        :param n: int
+                  Number of stages of the PUF
+        :param k: int
+                  Number different LTFArrays
+        :param N: int
+                  Number of challenges which are generated in order to learn the PUF simulation.
+        :param seed_instance: int
+                              The seed which is used to initialize the pseudo-random number generator
+                              which is used to generate the stage weights for the arbiter PUF simulation.
+        :param seed_model: int
+                           The seed which is used to initialize the pseudo-random number generator
+                           which is used to generate the stage weights for the learner arbiter PUF simulation.
+        :param transformation: A function: array of int with shape(N,k,n), int number of PUFs k -> shape(N,k,n)
+                               The function transforms input challenges in order to increase resistance against attacks.
+        :param combiner: A function: array of int with shape(N,k,n) -> array of in with shape(N)
+                         The functions combines the outputs of k PUFs to one bit results,
+                         in oder to increase resistance against attacks.
+        """
         super().__init__(
             log_name='%s.0x%x_0x%x_0_%i_%i_%i_%s_%s' % (
                 log_name,
@@ -68,18 +92,18 @@ class ExperimentLogisticRegression(Experiment):
 
         self.result_logger.info(
             # seed_instance  seed_model i      n      k      N      trans  comb   iter   time   accuracy  model values
-            '0x%x\t'        '0x%x\t'   '%i\t' '%i\t' '%i\t' '%i\t' '%s\t' '%s\t' '%i\t' '%f\t' '%f\t'    '%s' % (
-                self.seed_instance,
-                self.seed_model,
-                0,  # restart count, kept for compatibility to old log files
-                self.n,
-                self.k,
-                self.N,
-                self.transformation.__name__,
-                self.combiner.__name__,
-                self.learner.iteration_count,
-                self.measured_time,
-                1.0 - tools.approx_dist(self.instance, self.model, min(10000, 2 ** self.n)),
-                ','.join(map(str, self.model.weight_array.flatten() / norm(self.model.weight_array.flatten())))
-            )
+            '0x%x\t'        '0x%x\t'   '%i\t' '%i\t' '%i\t' '%i\t' '%s\t' '%s\t' '%i\t' '%f\t' '%f\t'    '%s',
+            self.seed_instance,
+            self.seed_model,
+            0,  # restart count, kept for compatibility to old log files
+            self.n,
+            self.k,
+            self.N,
+            self.transformation.__name__,
+            self.combiner.__name__,
+            self.learner.iteration_count,
+            self.measured_time,
+            1.0 - tools.approx_dist(self.instance, self.model, min(10000, 2 ** self.n)),
+            ','.join(map(str, self.model.weight_array.flatten() / norm(self.model.weight_array.flatten())))
+
         )

--- a/pypuf/experiments/experiment/majority_vote.py
+++ b/pypuf/experiments/experiment/majority_vote.py
@@ -1,3 +1,8 @@
+"""
+This module provides an experiment class which implements an experiment in order to find an approximately  minimal
+number of votes for a Majority Vote Arbiter PUF which satisfy the chosen desired_stability and
+overall_desired_stability.
+"""
 import numpy as np
 from numpy.random import RandomState
 from pypuf import tools
@@ -41,7 +46,6 @@ class ExperimentMajorityVoteFindVotes(Experiment):
         :param sigma_noise_ratio: float
                                   The noisiness factor which is used to scale sigma_noise. The value sigma_noise
                                   is the standard deviation of the noise distribution of the PUF instance simulation.
-        
         :param seed_challenges: int
                                 The seed which is used to initialize the pseudo-random number generator which
                                 is used to generate challenges.
@@ -165,7 +169,7 @@ class ExperimentMajorityVoteFindVotes(Experiment):
         """
         Calculate the stability for random chosen challenges.
         :param instance: SimulationMajorityLTFArray
-                         A simulation of a Majority Vote Arbiter PUF. 
+                         A simulation of a Majority Vote Arbiter PUF.
         :param challenge_prng: RandomState
                                Pseudo-random number generator which is used to generate challenges.
         """

--- a/pypuf/experiments/experiment/majority_vote.py
+++ b/pypuf/experiments/experiment/majority_vote.py
@@ -27,7 +27,7 @@ class ExperimentMajorityVoteFindVotes(Experiment):
                               The seed which is used to initialize the pseudo-random number generator
                               which is used to generate the stage weights for the arbiter PUF simulation.
         :param seed_instance_noise: int
-                                    The random seed which is used to initialize the pseudo-random number
+                                    The seed which is used to initialize the pseudo-random number
                                     generator which is used to generate the noise for the arbiter PUF simulation.
         :param transformation: A function: array of int with shape(N,k,n), int number of PUFs k -> shape(N,k,n)
                                The function transforms input challenges in order to increase resistance against attacks.
@@ -40,8 +40,7 @@ class ExperimentMajorityVoteFindVotes(Experiment):
                       Standard deviation of the stage weight distribution of the PUF instance simulation.
         :param sigma_noise_ratio: float
                                   The noisiness factor which is used to scale sigma_noise. The value sigma_noise
-                                  is the standard deviation of the stage weight distribution of the PUF instance
-                                  simulation.
+                                  is the standard deviation of the noise distribution of the PUF instance simulation.
         
         :param seed_challenges: int
                                 The seed which is used to initialize the pseudo-random number generator which

--- a/pypuf/experiments/experimenter.py
+++ b/pypuf/experiments/experimenter.py
@@ -1,5 +1,25 @@
+"""
+This module provides a class which acts as process pool. The is build in order to distribute several experiments over
+the system cores. The results of the experiments are written into on a single log file which is coordinated by a logging
+process. In order to run experiments a path to a logfile and list of experiments is needed which inherit the
+pypuf.experiments.experiment.base class.
+
+Example usage:
+
+experiments = []
+n = 128
+for i in range(n):
+    log_name = 'test_multiprocessing_logs{0}'.format(i)
+    experiment = Experiment(...)
+    experiments.append(experiment)
+
+experimenter = Experimenter('experimenter_log_path', experiments)
+experimenter.run()
+"""
 import multiprocessing
 import logging
+import sys
+import traceback
 
 
 class Experimenter(object):
@@ -41,17 +61,29 @@ class Experimenter(object):
         for exp in self.experiments:
 
             # define experiment process
-            def run_experiment(queue, semaphore, logger_name):
+            def run_experiment(experiment, queue, semaphore, logger_name):
+                """
+                This method is responsible to start the experiment and release the semaphore which coordinates the
+                number of parallel running processes.
+                :param experiment: pypuf.experiments.experiment.base.Experiment
+                                   A implementation of the base experiment class which should be executed
+                :param queue: multiprocessing.queue
+                              This is used to coordinate the processes in order to obtain results.
+                :param semaphore: multiprocessing.BoundedSemaphore(self.cpu_limit)
+                                  A semaphore to limit the number of concurrent running experiments
+                :param logger_name: String
+                                    Path to or name to the log file of the experiment
+                """
                 try:
-                    exp.execute(queue, logger_name)  # run the actual experiment
+                    experiment.execute(queue, logger_name)  # run the actual experiment
                     semaphore.release()  # release CPU
-                except Exception as e:
+                except Exception as experiment:  # pylint: disable=W
                     semaphore.release()  # release CPU
-                    raise e
+                    raise experiment
 
             job = multiprocessing.Process(
                 target=run_experiment,
-                args=(queue, self.semaphore, self.logger_name)
+                args=(exp, queue, self.semaphore, self.logger_name)
             )
 
             # wait for a free CPU
@@ -84,6 +116,12 @@ class Experimenter(object):
 
 
 def setup_logger(logger_name):
+    """
+    This method is used to open the file handler for a logger_name. The resulting log file will have the format
+    'logger_namer.log'.
+    :param logger_name: string
+                        Path to or name to the log file
+    """
     root = logging.getLogger(logger_name)
 
     # Setup logging to both file and console
@@ -94,6 +132,14 @@ def setup_logger(logger_name):
 
 
 def log_listener(queue, configurer, logger_name):
+    """
+    This is the root function of logging process which is responsible to log the experiment results.
+    :param queue: multiprocessing.queue
+                  This is used to coordinate the processes in order to obtain results.
+    :param configurer: A function which setup the logger which logs the messages read from the queue.
+    :param logger_name: String
+                        Path to or name to the log file
+    """
     configurer(logger_name)
     while True:
         try:
@@ -102,7 +148,6 @@ def log_listener(queue, configurer, logger_name):
                 break
             logger = logging.getLogger(record.name)
             logger.handle(record)  # No level or filter logic applied - just do it!
-        except Exception:
-            import sys, traceback
+        except Exception:  # pylint: disable=W
             print('Whoops! Problem:', file=sys.stderr)
             traceback.print_exc(file=sys.stderr)

--- a/pypuf/learner/regression/logistic_regression.py
+++ b/pypuf/learner/regression/logistic_regression.py
@@ -14,21 +14,7 @@ class LogisticRegression(Learner):
     models that fit the LTF Array as defined in the constructor.
     """
 
-    class ModelUpdate(object):
-        """
-        Model update according to the naive algorithm. Works, but is really slow to converge.
-        """
-
-        def __init__(self, model):
-            model = model
-
-        def update(self, gradient):
-            """
-            Use the gradient scaled with a constant to determine the update step.
-            """
-            return -.3 * gradient
-
-    class RPropModelUpdate(ModelUpdate):
+    class RPropModelUpdate():
         """
         Model update according to the Resilient Backpropagation algorithm. For details, see update() method.
         """

--- a/pypuf/learner/regression/logistic_regression.py
+++ b/pypuf/learner/regression/logistic_regression.py
@@ -110,7 +110,7 @@ class LogisticRegression(Learner):
         :param weights_prng: PRNG to draw the initial model from. Defaults to fresh `numpy.random.RandomState` instance.
         """
         self.iteration_count = 0
-        self.training_set = t_set
+        self.__training_set = t_set
         self.n = n
         self.k = k
         self.weights_mu = weights_mu

--- a/pypuf/learner/regression/logistic_regression.py
+++ b/pypuf/learner/regression/logistic_regression.py
@@ -159,9 +159,9 @@ class LogisticRegression(Learner):
         # compute the derivative from
         # the (-1,+1)-interval-sigmoid of combined model response on the all inputs
         # and the training set responses
+        # This is equivalent to
+        # self.set.responses * (1 - 1/(1 + exp(-self.set.responses * combined_model_responses)))
         self.sigmoid_derivative = .5 * (2 / (1 + exp(-combined_model_responses)) - 1 - self.training_set.responses)
-                                  # equivalent to self.set.responses *
-                                  #     (1 - 1/(1 + exp(-self.set.responses * combined_model_responses)))
 
         def model_gradient_xor(l):
             """ Compute Gradient for XOR Combiner Model (cf. LTFArray.combiner_xor) """

--- a/pypuf/learner/regression/logistic_regression.py
+++ b/pypuf/learner/regression/logistic_regression.py
@@ -21,6 +21,8 @@ class LogisticRegression(Learner):
     models that fit the LTF Array as defined in the constructor.
     """
 
+    MAX_RESPONSE_ABS_VALUE = 50
+
     class RPropModelUpdate():
         """
         Model update according to the Resilient Backpropagation algorithm. For details, see update() method.
@@ -149,12 +151,10 @@ class LogisticRegression(Learner):
         self.sign_combined_model_responses = sign(combined_model_responses)
 
         # cap the absolute value of this to avoid overflow errors
-        MAX_RESPONSE_ABS_VALUE = 50
-        combined_model_responses = sign(combined_model_responses) * \
-                                   minimum(
-                                       full(len(combined_model_responses), MAX_RESPONSE_ABS_VALUE, double),
-                                       abs(combined_model_responses)
-                                   )
+        combined_model_responses = sign(combined_model_responses) * minimum(
+            full(len(combined_model_responses), self.MAX_RESPONSE_ABS_VALUE, double),
+            abs(combined_model_responses)
+        )
 
         # compute the derivative from
         # the (-1,+1)-interval-sigmoid of combined model response on the all inputs

--- a/pypuf/learner/regression/logistic_regression.py
+++ b/pypuf/learner/regression/logistic_regression.py
@@ -40,7 +40,8 @@ class LogisticRegression(Learner):
         def update(self, grad):
             """
             Compute update step according to "Resilient Backpropagation" by
-            Riedmiller, Martin, and Heinrich Braun. "A direct adaptive method for faster backpropagation learning: The RPROP algorithm."
+            Riedmiller, Martin, and Heinrich Braun. "A direct adaptive method for faster
+            backpropagation learning: The RPROP algorithm."
             Neural Networks, 1993., IEEE International Conference on. IEEE, 1993.
 
             Implementation following the neat implementation used in
@@ -61,9 +62,12 @@ class LogisticRegression(Learner):
                 self.step_size[l] = amin((self.step_size[l], self.step_size_max), 0)
                 self.step_size[l] = amax((self.step_size[l], self.step_size_min), 0)
 
-                self.step[l][step_indicator > 0] = -(self.step_size[l][step_indicator > 0] * sign(grad_l[step_indicator > 0]))
-                self.step[l][step_indicator < 0] = -self.last_step_size[l][step_indicator < 0]
-                self.step[l][step_indicator == 0] = -self.step_size[l][step_indicator == 0] * sign(grad_l[step_indicator == 0])
+                self.step[l][step_indicator > 0] = \
+                    -(self.step_size[l][step_indicator > 0] * sign(grad_l[step_indicator > 0]))
+                self.step[l][step_indicator < 0] = \
+                    -self.last_step_size[l][step_indicator < 0]
+                self.step[l][step_indicator == 0] = \
+                    -self.step_size[l][step_indicator == 0] * sign(grad_l[step_indicator == 0])
 
                 self.last_gradient[l] = grad_l
                 self.last_gradient[l][step_indicator < 0] = 0
@@ -71,7 +75,18 @@ class LogisticRegression(Learner):
 
             return self.step
 
-    def __init__(self, t_set, n, k, transformation=LTFArray.transform_id, combiner=LTFArray.combiner_xor, weights_mu=0, weights_sigma=1, weights_prng=RandomState(), logger=None):
+    def __init__(
+            self,
+            t_set,
+            n,
+            k,
+            transformation=LTFArray.transform_id,
+            combiner=LTFArray.combiner_xor,
+            weights_mu=0,
+            weights_sigma=1,
+            weights_prng=RandomState(),
+            logger=None
+    ):
         """
         Initialize a LTF Array Logistic Regression Learner for the specified LTF Array.
 
@@ -79,7 +94,8 @@ class LogisticRegression(Learner):
         :param n: Input length
         :param k: Number of parallel LTFs in the LTF Array
         :param transformation: Input transformation used by the LTF Array
-        :param combiner: Combiner Function used by the LTF Array (Note that not all combiner functions are supported by this class.)
+        :param combiner: Combiner Function used by the LTF Array (Note that not all combiner functions are supported by
+            this class.)
         :param weights_mu: mean of the Gaussian that is used to choose the initial model
         :param weights_sigma: standard deviation of the Gaussian that is used to choose the initial model
         :param weights_prng: PRNG to draw the initial model from. Defaults to fresh `numpy.random.RandomState` instance.
@@ -137,7 +153,8 @@ class LogisticRegression(Learner):
         # the (-1,+1)-interval-sigmoid of combined model response on the all inputs
         # and the training set responses
         self.sigmoid_derivative = .5 * (2 / (1 + exp(-combined_model_responses)) - 1 - self.training_set.responses)
-                                  # equivalent to self.set.responses * (1 - 1/(1 + exp(-self.set.responses * combined_model_responses)))
+                                  # equivalent to self.set.responses *
+                                  #     (1 - 1/(1 + exp(-self.set.responses * combined_model_responses)))
 
         def model_gradient_xor(l):
             #         Prod_i < w_i x_i >    /  < w_l x_l >          = Prod_(i \neq j)  < w_i x_i >
@@ -200,7 +217,13 @@ class LogisticRegression(Learner):
 
         # we start with a random model
         model = LTFArray(
-            weight_array=LTFArray.normal_weights(self.n, self.k, self.weights_mu, self.weights_sigma, self.weights_prng),
+            weight_array=LTFArray.normal_weights(
+                self.n,
+                self.k,
+                self.weights_mu,
+                self.weights_sigma,
+                self.weights_prng
+            ),
             transform=self.transformation,
             combiner=self.combiner,
         )
@@ -224,7 +247,11 @@ class LogisticRegression(Learner):
             ).all()
 
             # check accuracy
-            distance = (self.training_set.N - count_nonzero(self.training_set.responses == self.sign_combined_model_responses)) / self.training_set.N
+            distance = (
+                           self.training_set.N - count_nonzero(
+                               self.training_set.responses == self.sign_combined_model_responses
+                           )
+                       ) / self.training_set.N
             self.min_distance = min(distance, self.min_distance)
 
             # log

--- a/pypuf/simulation/arbiter_based/ltfarray.py
+++ b/pypuf/simulation/arbiter_based/ltfarray.py
@@ -1,5 +1,10 @@
-from numpy import sum, prod, shape, sign, dot, array, tile, transpose, concatenate, dstack, swapaxes, sqrt, amax,\
-    vectorize, tile
+"""
+This module provides several different implementations of arbiter PUF simulations. The linear threshold function array
+model is the core of each simulation class.
+"""
+from numpy import prod, shape, sign, dot, array, tile, transpose, concatenate, dstack, swapaxes, sqrt, amax, \
+    vectorize
+from numpy import sum as np_sum
 from numpy.random import RandomState
 from pypuf import tools
 from pypuf.simulation.base import Simulation
@@ -12,74 +17,97 @@ class LTFArray(Simulation):
     """
 
     @staticmethod
-    def combiner_xor(r):
+    def combiner_xor(responses):
         """
         combines output responses with the XOR operation
-        :param r: a list with a number of vectors of single LTF results
-        :return: a list of full results, one for each
+        :param responses: Array of int of float with shape(N,k,n)
+                          An Array with a number of vectors of single LTF results
+        :return: array of float or int shape(N)
+                 Array of responses for the N different challenges.
         """
-        return prod(r, 1)
+        return prod(responses, 1)
 
     @staticmethod
-    def combiner_ip_mod2(r):
+    def combiner_ip_mod2(responses):
         """
         combines output responses with the inner product mod 2 operation
-        :param r: a list with a number of vectors of single LTF results
-        :return: a list of full results, one for each
+        :param responses: a array with a number of vectors of single LTF results
+        :return: array of float or int shape(N)
+                 Array of responses for the N different challenges.
         """
-        n = len(r[0])
-        assert n % 2 == 0, 'IP mod 2 is only defined for even n. Sorry!'
+        n = len(responses[0])
+        assert n % 2 == 0, 'IP mod 2 is only defined for even n.'
         return prod(
             transpose(
                 [
-                    amax((r[:,i], r[:,i+1]), 0)
+                    amax((responses[:, i], responses[:, i + 1]), 0)
                     for i in range(0, n, 2)
-                ])
-            , 1)
+                ]),
+            1
+        )
 
     @staticmethod
-    def transform_id(cs, k):
+    def transform_id(challenges, k):
         """
         Input transformation that does nothing.
-        :return:
+        :param challenges: array of int shape(N,k,n)
+                           Array of challenges which should be evaluated by the simulation.
+        :param k: int
+                  Number of LTFArray PUFs
+        :return:  array of int shape(N,k,n)
+                  Array of transformed challenges.
         """
         return array([
-                tile(c, (k, 1))  # same unmodified challenge for all k LTFs
-                for c in cs
-            ])
+            tile(c, (k, 1))  # same unmodified challenge for all k LTFs
+            for c in challenges
+        ])
 
     @staticmethod
-    def transform_atf(cs, k):
+    def transform_atf(challenges, k):
         """
         Input transformation that simulates an Arbiter PUF
-        :return:
+        :param challenges: array of int shape(N,k,n)
+                           Array of challenges which should be evaluated by the simulation.
+        :param k: int
+                  Number of LTFArray PUFs
+        :return:  array of int shape(N,k,n)
+                  Array of transformed challenges.
         """
 
         # Transform with ATF monomials
-        cs = transpose(
+        challenges = transpose(
             array([
-                prod(cs[:,i:], 1)
-                for i in range(len(cs[0]))
+                prod(challenges[:, i:], 1)
+                for i in range(len(challenges[0]))
             ])
         )
 
         # Same challenge for all k Arbiters
-        return __class__.transform_id(cs, k)
+        return LTFArray.transform_id(challenges, k)
 
     @staticmethod
-    def transform_mm(cs, k):
-        N = len(cs)
-        n = len(cs[0])
-        assert k == 2, 'MM transform currently only implemented for k=2. Sorry!'
-        assert n % 2 == 0, 'MM transform only defined for even n. Sorry!'
+    def transform_mm(challenges, k):
+        """
+        Input transformation that transforms nice.
+        :param challenges: array of int shape(N,k,n)
+                           Array of challenges which should be evaluated by the simulation.
+        :param k: int
+                  Number of LTFArray PUFs
+        :return:  array of int shape(N,k,n)
+                  Array of transformed challenges.
+        """
+        N = len(challenges)
+        n = len(challenges[0])
+        assert k == 2, 'MM transform currently only implemented for k=2.'
+        assert n % 2 == 0, 'MM transform only defined for even n.'
 
-        cs_1 = cs
+        cs_1 = challenges
         cs_2 = transpose(
-                concatenate(
+            concatenate(
                 (
-                    [ cs[:,0] ],
-                    [ cs[:,i] * cs[:,i+1] for i in range(0, n, 2) ],
-                    [ cs[:,i] * cs[:,i+1] * cs[:,i+2] for i in range(0, n-2, 2) ]
+                    [challenges[:, 0]],
+                    [challenges[:, i] * challenges[:, i + 1] for i in range(0, n, 2)],
+                    [challenges[:, i] * challenges[:, i + 1] * challenges[:, i + 2] for i in range(0, n - 2, 2)]
                 )
             )
         )
@@ -89,17 +117,23 @@ class LTFArray(Simulation):
         return result
 
     @staticmethod
-    def transform_lightweight_secure_original(cs, k):
+    def transform_lightweight_secure_original(challenges, k):
         """
         Input transform as defined by Majzoobi et al. 2008.
+        :param challenges: array of int shape(N,k,n)
+                           Array of challenges which should be evaluated by the simulation.
+        :param k: int
+                  Number of LTFArray PUFs
+        :return:  array of int shape(N,k,n)
+                  Array of transformed challenges.
         """
-        N = len(cs)
-        n = len(cs[0])
-        assert n % 2 == 0, 'Secure Lightweight Input Transformation only defined for even n. Sorry!'
+        N = len(challenges)
+        n = len(challenges[0])
+        assert n % 2 == 0, 'Secure Lightweight Input Transformation only defined for even n.'
 
-        cs_shift_trans = __class__.transform_shift_lightweight_secure(cs, k)
+        cs_shift_trans = LTFArray.transform_shift_lightweight_secure(challenges, k)
 
-        """ Perform atf transform """
+        # Perform atf transform
         result = transpose(
             array([
                 prod(cs_shift_trans[:, :, i:], 2)
@@ -108,94 +142,121 @@ class LTFArray(Simulation):
             (1, 2, 0)
         )
 
-        assert result.shape == (N, k, n), 'The resulting challenges have not the desired shape. Sorry!'
+        assert result.shape == (N, k, n), 'The resulting challenges have not the desired shape.'
 
         return result
 
     @staticmethod
-    def transform_lightweight_secure(cs, k):
+    def transform_lightweight_secure(challenges, k):
         """
         Input transform as defined by Majzoobi et al. 2008, but with the shift
         operation executed after and without ATF transform.
+        :param challenges: array of int shape(N,k,n)
+                           Array of challenges which should be evaluated by the simulation.
+        :param k: int
+                  Number of LTFArray PUFs
+        :return:  array of int shape(N,k,n)
+                  Array of transformed challenges.
         """
-        N = len(cs)
-        n = len(cs[0])
-        assert n % 2 == 0, 'Secure Lightweight Input Transformation only defined for even n. Sorry!'
+        N = len(challenges)
+        n = len(challenges[0])
+        assert n % 2 == 0, 'Secure Lightweight Input Transformation only defined for even n.'
 
-        cs = transpose(
-                concatenate(
+        challenges = transpose(
+            concatenate(
                 (
-                    [ cs[:,i] * cs[:,i+1] for i in range(0, n, 2) ],    # ( x1x2, x3x4, ... xn-1xn )
-                    [ cs[:,0] ],                                        # ( x1 )
-                    [ cs[:,i] * cs[:,i+1] for i in range(1, n-2, 2) ],  # ( x2x3, x4x5, ... xn-2xn-1 )
+                    [challenges[:, i] * challenges[:, i + 1] for i in range(0, n, 2)],  # (x1x2, x3x4, ... xn-1xn)
+                    [challenges[:, 0]],  # (x1)
+                    [challenges[:, i] * challenges[:, i + 1] for i in range(1, n - 2, 2)],  # (x2x3, x4x5, ... xn-2xn-1)
                 )
             )
         )
 
-        assert cs.shape == (N, n)
+        assert challenges.shape == (N, n)
 
-        return __class__.transform_shift(cs, k)
+        return LTFArray.transform_shift(challenges, k)
 
     @staticmethod
-    def transform_shift_lightweight_secure(cs, k):
+    def transform_shift_lightweight_secure(challenges, k):
         """
         Input transform as defined by Majzoobi et al. 2008, with the shift
         operation executed first and without ATF transform.
+        :param challenges: array of int shape(N,k,n)
+                           Array of challenges which should be evaluated by the simulation.
+        :param k: int
+                  Number of LTFArray PUFs
+        :return:  array of int shape(N,k,n)
+                  Array of transformed challenges.
         """
-        N = len(cs)
-        n = len(cs[0])
-        assert n % 2 == 0, 'Secure Lightweight Input Transformation only defined for even n. Sorry!'
+        N = len(challenges)
+        n = len(challenges[0])
+        assert n % 2 == 0, 'Secure Lightweight Input Transformation only defined for even n.'
 
-        shifted = __class__.transform_shift(cs, k)
+        shifted = LTFArray.transform_shift(challenges, k)
 
-        cs = transpose(
+        challenges = transpose(
             concatenate(
                 (
-                    [ shifted[:,:,i] * shifted[:,:,i+1] for i in range(0, n, 2) ],
-                    [ shifted[:,:,0] ],
-                    [ shifted[:,:,i] * shifted[:,:,i+1] for i in range(1, n-2, 2) ],
+                    [shifted[:, :, i] * shifted[:, :, i + 1] for i in range(0, n, 2)],
+                    [shifted[:, :, 0]],
+                    [shifted[:, :, i] * shifted[:, :, i + 1] for i in range(1, n - 2, 2)],
                 )
             ),
             (1, 2, 0)
         )
 
-        assert cs.shape == (N, k, n)
+        assert challenges.shape == (N, k, n)
 
-        return cs
+        return challenges
 
     @staticmethod
-    def transform_soelter_lightweight_secure(cs, k):
+    def transform_soelter_lightweight_secure(challenges, k):
         """
         Input transformation like defined by Majzoobi et al. (cf. transform_lightweight_secure),
         but differs in one bit. Introduced by Sölter.
+        :param challenges: array of int shape(N,k,n)
+                           Array of challenges which should be evaluated by the simulation.
+        :param k: int
+                  Number of LTFArray PUFs
+        :return:  array of int shape(N,k,n)
+                  Array of transformed challenges.
         """
-        N = len(cs)
-        n = len(cs[0])
-        assert n % 2 == 0, 'Sölter\'s Secure Lightweight Input Transformation only defined for even n. Sorry!'
-        n_half = int(n/2)
+        N = len(challenges)
+        n = len(challenges[0])
+        assert n % 2 == 0, 'Sölter\'s Secure Lightweight Input Transformation only defined for even n.'
+        n_half = int(n / 2)
 
-        cs = transpose(
+        challenges = transpose(
             concatenate(
                 (
-                    [cs[:, i] * cs[:, i + 1] for i in range(0, n, 2)],      # ( x1x2, x3x4, ... xn-1xn )
-                    [cs[:, n_half]],                                        # ( x_(n/2+1) )
-                    [cs[:, i] * cs[:, i + 1] for i in range(1, n - 2, 2)],  # ( x2x3, x4x5, ... xn-2xn-1 )
+                    [challenges[:, i] * challenges[:, i + 1] for i in range(0, n, 2)],  # (x1x2, x3x4, ... xn-1xn)
+                    [challenges[:, n_half]],  # (x_(n/2+1))
+                    [challenges[:, i] * challenges[:, i + 1] for i in range(1, n - 2, 2)],  # (x2x3, x4x5, ... xn-2xn-1)
                 )
             )
         )
 
-        assert cs.shape == (N, n)
+        assert challenges.shape == (N, n)
 
-        return __class__.transform_shift(cs, k)
+        return LTFArray.transform_shift(challenges, k)
 
     @staticmethod
-    def transform_shift(cs, k):
+    def transform_shift(challenges, k):
+        """
+        Input transformation that shifts the input bits for each of the k PUFs.
+        :param challenges: array of int shape(N,k,n)
+                           Array of challenges which should be evaluated by the simulation.
+        :param k: int
+                  Number of LTFArray PUFs
+        :return:  array of int shape(N,k,n)
+                  Array of transformed challenges.
+        """
 
-        N = len(cs)
-        n = len(cs[0])
+        N = len(challenges)
+        n = len(challenges[0])
 
         result = swapaxes(array([
-            concatenate((cs[:,l:], cs[:,:l]), axis=1)
+            concatenate((challenges[:, l:], challenges[:, :l]), axis=1)
             for l in range(k)
         ]), 0, 1)
 
@@ -204,24 +265,30 @@ class LTFArray(Simulation):
         return result
 
     @staticmethod
-    def transform_1_n_bent(cs, k):
+    def transform_1_n_bent(challenges, k):
         """
         For one LTF, we compute the input as follows: the i-th input bit will be the result
         of the challenge shifted by i bits to the left, then input into inner product mod 2
         function.
         The other LTF get the original input.
+        :param challenges: array of int shape(N,k,n)
+                           Array of challenges which should be evaluated by the simulation.
+        :param k: int
+                  Number of LTFArray PUFs
+        :return:  array of int shape(N,k,n)
+                  Array of transformed challenges.
         """
-        N = len(cs)
-        n = len(cs[0])
-        assert n % 2 == 0, '1-n bent transform only defined for even n. Sorry!'
+        N = len(challenges)
+        n = len(challenges[0])
+        assert n % 2 == 0, '1-n bent transform only defined for even n.'
 
-        shift_challenges = __class__.transform_shift(cs, n)
+        shift_challenges = LTFArray.transform_shift(challenges, n)
         assert shift_challenges.shape == (N, n, n)
 
         bent_challenges = transpose(
             array(
                 [
-                    __class__.combiner_ip_mod2(shift_challenges[:,i,:])
+                    LTFArray.combiner_ip_mod2(shift_challenges[:, i, :])
                     for i in range(n)
                 ]
             )
@@ -229,45 +296,52 @@ class LTFArray(Simulation):
         assert bent_challenges.shape == (N, n)
 
         return array([
-                concatenate(
-                    (
-                        [bent_challenges[j]],    # 'bent' challenge as generated above
-                        tile(cs[j], (k - 1, 1))  # unmodified challenge for k-1 LTFs
-                    ),
-                    axis=0
-                )
-                for j in range(N)
-            ])
+            concatenate(
+                (
+                    [bent_challenges[j]],  # 'bent' challenge as generated above
+                    tile(challenges[j], (k - 1, 1))  # unmodified challenge for k-1 LTFs
+                ),
+                axis=0
+            )
+            for j in range(N)
+        ])
 
     @staticmethod
-    def transform_1_1_bent(cs, k):
+    def transform_1_1_bent(challenges, k):
         """
         For one LTF, we compute the input as follows: the first input bit will be
         the result of IPmod2 of the original challenge, all other input bits will
         remain the same.
         The other LTF get the original input.
+        :param challenges: array of int shape(N,k,n)
+                           Array of challenges which should be evaluated by the simulation.
+        :param k: int
+                  Number of LTFArray PUFs
+        :return:  array of int shape(N,k,n)
+                  Array of transformed challenges.
         """
-        N = len(cs)
-        n = len(cs[0])
-        assert k >= 2, '1-n bent transform currently only implemented for k>=2. Sorry!'
-        assert n % 2 == 0, '1-n bent transform only defined for even n. Sorry!'
+        N = len(challenges)
+        n = len(challenges[0])
+        assert k >= 2, '1-n bent transform currently only implemented for k>=2.'
+        assert n % 2 == 0, '1-n bent transform only defined for even n.'
 
-        bent_challenge_bits = __class__.combiner_ip_mod2(cs)
-        assert bent_challenge_bits.shape == (N, )
+        bent_challenge_bits = LTFArray.combiner_ip_mod2(challenges)
+        assert bent_challenge_bits.shape == (N,)
 
         return array([
-                concatenate(
-                    (
-                        [concatenate(([[bent_challenge_bits[j]], cs[j][1:]]))],  # 'bent' challenge bit plus remainder unchanged
-                        tile(cs[j], (k - 1, 1))                  # unmodified challenge for k-1 LTFs
-                    ),
-                    axis=0
-                )
-                for j in range(N)
-            ])
+            concatenate(
+                (
+                    [concatenate(([[bent_challenge_bits[j]], challenges[j][1:]]))],
+                    # 'bent' challenge bit plus remainder unchanged
+                    tile(challenges[j], (k - 1, 1))  # unmodified challenge for k-1 LTFs
+                ),
+                axis=0
+            )
+            for j in range(N)
+        ])
 
     @staticmethod
-    def transform_polynomial(cs, k):
+    def transform_polynomial(challenges, k):
         """
         This input transformation interprets a challenge c as a
         polynomial over the finite field GF(2^n)=F2/f*F2, where f is a
@@ -276,110 +350,145 @@ class LTFArray(Simulation):
         of degree 8, 16, 24, 32, 48, or 64.
         Each Arbiter Chain i receives as input the polynomial c^i
         as element of GF(2^n).
+        :param challenges: array of int shape(N,k,n)
+                           Array of challenges which should be evaluated by the simulation.
+        :param k: int
+                  Number of LTFArray PUFs
+        :return:  array of int shape(N,k,n)
+                  Array of transformed challenges.
         """
 
-        N = len(cs)
-        n = len(cs[0])
-        assert n in [8, 16, 24, 32, 48, 64], 'Polynomial transformation is only implemented for challenges with n in {8, 16, 24, 32, 48, 64}. ' \
-                                       'Sorry!'
+        N = len(challenges)
+        n = len(challenges[0])
+        assert n in [8, 16, 24, 32, 48, 64], 'Polynomial transformation is only implemented for challenges with n in ' \
+                                             '{8, 16, 24, 32, 48, 64}.'
         if n == 64:
-            f = array([1, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                 0, 0, 0, 0, 0, 0, 0, 0, 1])
+            irreducible_polynomial = array(
+                [1, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]
+            )
         elif n == 48:
-            f = array([1, 0, 1, 1, 0, 1, 0, 0, 1, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 0, 1, 0, 0, 1, 0, 1, 1, 0, 1,
-                 0, 0, 1])
+            irreducible_polynomial = array(
+                [1, 0, 1, 1, 0, 1, 0, 0, 1, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0,
+                 1, 1, 0, 1, 0, 0, 1, 0, 1, 1, 0, 1, 0, 0, 1]
+            )
         elif n == 32:
-            f = array([1, 0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                       0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
+            irreducible_polynomial = array(
+                [1, 0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]
+            )
         elif n == 24:
-            f = array([1, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
+            irreducible_polynomial = array([1, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
         elif n == 16:
-            f = array([1, 0, 1, 0, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 1, 1, 1])
+            irreducible_polynomial = array([1, 0, 1, 0, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 1, 1, 1])
         elif n == 8:
-            f = array([1, 0, 1, 0, 0, 1, 1, 0, 1])
+            irreducible_polynomial = array([1, 0, 1, 0, 0, 1, 1, 0, 1])
 
-        """ Transform challenge to 0,1 array to compute transformation with numpy. """
+        # Transform challenge to 0,1 array to compute transformation with numpy.
         vtransform_to_01 = vectorize(tools.transform_challenge_11_to_01)
-        cs_01 = array([vtransform_to_01(c) for c in cs])
+        cs_01 = array([vtransform_to_01(c) for c in challenges])
 
-        """ Compute c^i for each challenge for i from 1 to k. """
-        cs = concatenate([
-                [tools.poly_mult_div(c, f, k) for c in cs_01]
+        # Compute c^i for each challenge for i from 1 to k.
+        challenges = concatenate([
+            [tools.poly_mult_div(c, irreducible_polynomial, k) for c in cs_01]
         ])
 
-        """ Transform challenges back to -1,1 notation. """
+        # Transform challenges back to -1,1 notation.
         vtransform_to_11 = vectorize(tools.transform_challenge_01_to_11)
-        result = array([vtransform_to_11(c) for c in cs])
+        result = array([vtransform_to_11(c) for c in challenges])
 
-        assert result.shape == (N, k, n), 'The resulting challenges have not the desired shape. Sorry!'
+        assert result.shape == (N, k, n), 'The resulting challenges have not the desired shape.'
         return result
 
     @staticmethod
-    def transform_permutation_atf(cs, k):
+    def transform_permutation_atf(challenges, k):
         """
         This transformation performs first a pseudorandom permutation of the challenge k times before applying the
         ATF transformation to each challenge.
-        :param cs:
-        :param k:
-        :return:
+        :param challenges: array of int shape(N,k,n)
+                           Array of challenges which should be evaluated by the simulation.
+        :param k: int
+                  Number of LTFArray PUFs
+        :return:  array of int shape(N,k,n)
+                  Array of transformed challenges.
         """
-        N = len(cs)
-        n = len(cs[0])
+        N = len(challenges)
+        n = len(challenges[0])
         seed = 0x1234
 
-        """ Perform random permutations """
+        # Perform random permutations
         cs_permuted = array(
             [
                 [RandomState(seed + i).permutation(c)
                  for i in range(k)]
-                 for c in cs
-                ]
+                for c in challenges
+            ]
         )
-        """ Perform atf transform """
+        # Perform atf transform
         result = transpose(
             array([
-                      prod(cs_permuted[:, :, i:], 2)
-                      for i in range(n)
-                      ]),
+                prod(cs_permuted[:, :, i:], 2)
+                for i in range(n)
+            ]),
             (1, 2, 0)
         )
 
-        assert result.shape == (N, k, n), 'The resulting challenges have not the desired shape. Sorry!'
+        assert result.shape == (N, k, n), 'The resulting challenges have not the desired shape.'
 
         return result
 
     @staticmethod
-    def transform_random(cs, k):
+    def transform_random(challenges, k):
         """
         This input transformation chooses for each Arbiter Chain an random challenge based on the initial challenge.
+        :param challenges: array of int shape(N,k,n)
+                           Array of challenges which should be evaluated by the simulation.
+        :param k: int
+                  Number of LTFArray PUFs
+        :return:  array of int shape(N,k,n)
+                  Array of transformed challenges.
         """
 
-        N = len(cs)
-        n = len(cs[0])
+        N = len(challenges)
+        n = len(challenges[0])
 
         vtransform_to_01 = vectorize(tools.transform_challenge_11_to_01)
-        cs_01 = array([vtransform_to_01(c) for c in cs])
+        cs_01 = array([vtransform_to_01(c) for c in challenges])
 
         result = array([RandomState(c).choice((-1, 1), (k, n)) for c in cs_01])
 
-        assert result.shape == (N, k, n), 'The resulting challenges have not the desired shape. Sorry!'
+        assert result.shape == (N, k, n), 'The resulting challenges have not the desired shape.'
         return result
 
     @staticmethod
-    def generate_stacked_transform(transform_1, kk, transform_2):
+    def generate_stacked_transform(transform_1, puf_count, transform_2):
         """
-        Returns an input transformation that will transform the first kk challenges using transform_1,
-        the remaining k - kk challenges using transform_2.
-        :return: A function that can perform the desired transformation
+        Returns an input transformation that will transform the first puf_count challenges using transform_1,
+        the remaining k - puf_count challenges using transform_2.
+        :param transform_1: A function: array of int with shape(N,k,n), int number of PUFs k -> shape(N,k,n)
+                            The function transforms input challenges in order to increase resistance against attacks.
+        :param puf_count: int
+                          Number of permutations to be used (must equal LTFArray.k)
+        :param transform_2: A function: array of int with shape(N,k,n), int number of PUFs k -> shape(N,k,n)
+                            The function transforms input challenges in order to increase resistance against attacks.
+        :return: A function: array of int with shape(N,k,n), int number of PUFs k -> shape(N,k,n)
+                 A function that can perform the desired transformation.
         """
-        def transform(cs, k):
-            (N,n) = cs.shape
-            transformed_1 = transform_1(cs, kk)
-            transformed_2 = transform_2(cs, k - kk)
-            assert transformed_1.shape == (N, kk, n)
-            assert transformed_2.shape == (N, k - kk, n)
+
+        def transform(challenges, k):
+            """
+           Method as described in generate_concatenated_transform doc string.
+           :param challenges: array of int shape(N,k,n)
+                              Array of challenges which should be evaluated by the simulation.
+           :param k: int
+                     Number of LTFArray PUFs
+           :return: A function: array of int with shape(N,k,n), int number of PUFs k -> shape(N,k,n)
+                    A function that can perform the desired transformation.
+           """
+            (N, n) = challenges.shape
+            transformed_1 = transform_1(challenges, puf_count)
+            transformed_2 = transform_2(challenges, k - puf_count)
+            assert transformed_1.shape == (N, puf_count, n)
+            assert transformed_2.shape == (N, k - puf_count, n)
             return concatenate(
                 (
                     transformed_1,
@@ -391,41 +500,55 @@ class LTFArray(Simulation):
         transform.__name__ = 'transform_stack_%s_nn%i_%s' % \
                              (
                                  transform_1.__name__.replace('transform_', ''),
-                                 kk,
+                                 puf_count,
                                  transform_2.__name__.replace('transform_', '')
                              )
 
         return transform
 
     @staticmethod
-    def generate_random_permutation_transform(seed, nn, kk, atf=False):
+    def generate_random_permutation_transform(seed, challenge_length, puf_count, atf=False):
         """
         Returns an input transformation that uses k pseudorandomly generated permutations
-        :param seed: Seed for the pseudorandom generation
-        :param nn: challenge length (must equal LTFArray.n)
-        :param kk: Number of permutations to be used (must equal LTFArray.k)
-        :param atf: Perform ATF transform after permuting
-        :return: The desired input transform
+        :param seed: int
+                     Seed for the pseudorandom generation
+        :param challenge_length: int
+                   Challenge length (must equal LTFArray.n)
+        :param puf_count: int
+                          Number of permutations to be used (must equal LTFArray.k)
+        :param atf: boolean
+                    Perform ATF transform after permuting
+        :return:  A function: array of int with shape(N,k,n), int number of PUFs k -> shape(N,k,n)
+                  A function that can perform the desired transformation.
         """
-        r = RandomState(seed)
-        permutations = [r.permutation(nn) for x in range(kk)]
+        prng = RandomState(seed)
+        permutations = [prng.permutation(challenge_length) for _ in range(puf_count)]
 
-        def transform(cs, k):
-            (N, n) = cs.shape
-            assert k == kk and n == nn, \
+        def transform(challenges, k):
+            """
+            Method as described in generate_concatenated_transform doc string.
+            :param challenges: array of int shape(N,k,n)
+                               Array of challenges which should be evaluated by the simulation.
+            :param k: int
+                     Number of LTFArray PUFs
+            :return: A function: array of int with shape(N,k,n), int number of PUFs k -> shape(N,k,n)
+                     A function that can perform the desired transformation.
+            """
+            (_, n) = challenges.shape
+            assert k == puf_count and n == challenge_length, \
                 'Permutations Input Transform cannot be used for LTFArrays with size other than defined'
 
             result = swapaxes(
                 array([
-                    cs[:, permutations[i]]
-                    for i in range(kk)
+                    challenges[:, permutations[i]]
+                    for i in range(puf_count)
                 ]),
                 0,
                 1
             )
 
             if atf:
-                """ Perform atf transform """
+                # Perform atf transform
                 result = transpose(
                     array([
                         prod(result[:, :, i:], 2)
@@ -440,20 +563,37 @@ class LTFArray(Simulation):
         return transform
 
     @staticmethod
-    def generate_concatenated_transform(transform_1, nn, transform_2):
+    def generate_concatenated_transform(transform_1, bit_number_transform_1, transform_2):
         """
-        Returns an input transformation that will transform the first nn bit of each challenge using transform_1,
-        the remaining bits using transform_2.
-        :return: A function that can perform the desired transformation
+        Returns an input transformation that will transform the first bit_number_transform_1 bit of each challenge using
+        transform_1, the remaining bits using transform_2.
+        :param transform_1: A function: array of int with shape(N,k,n), int number of PUFs k -> shape(N,k,n)
+                            The function transforms input challenges in order to increase resistance against attacks.
+        :param bit_number_transform_1: int
+                                       Number of challenge bits which be transformed with transform_1
+        :param transform_2: A function: array of int with shape(N,k,n), int number of PUFs k -> shape(N,k,n)
+                            The function transforms input challenges in order to increase resistance against attacks.
+        :return A function: array of int with shape(N,k,n), int number of PUFs k -> shape(N,k,n)
+                A function that can perform the desired transformation.
         """
-        def transform(cs, k):
-            (N,n) = cs.shape
-            cs1 = cs[:,:nn]
-            cs2 = cs[:,nn:]
-            transformed_1 = transform_1(cs1, k)
-            transformed_2 = transform_2(cs2, k)
-            assert transformed_1.shape == (N, k, nn)
-            assert transformed_2.shape == (N, k, n - nn)
+
+        def transform(challenges, k):
+            """
+            Method as described in generate_concatenated_transform doc string.
+            :param challenges: array of int shape(N,k,n)
+                               Array of challenges which should be evaluated by the simulation.
+            :param k: int
+                      Number of LTFArray PUFs
+            :return: A function: array of int with shape(N,k,n), int number of PUFs k -> shape(N,k,n)
+                     A function that can perform the desired transformation.
+            """
+            (N, n) = challenges.shape
+            challenges1 = challenges[:, :bit_number_transform_1]
+            challenges2 = challenges[:, bit_number_transform_1:]
+            transformed_1 = transform_1(challenges1, k)
+            transformed_2 = transform_2(challenges2, k)
+            assert transformed_1.shape == (N, k, bit_number_transform_1)
+            assert transformed_2.shape == (N, k, n - bit_number_transform_1)
             return concatenate(
                 (
                     transformed_1,
@@ -465,7 +605,7 @@ class LTFArray(Simulation):
         transform.__name__ = 'transform_concat_%s_nn%i_%s' % \
                              (
                                  transform_1.__name__.replace('transform_', ''),
-                                 nn,
+                                 bit_number_transform_1,
                                  transform_2.__name__.replace('transform_', '')
                              )
 
@@ -500,25 +640,39 @@ class LTFArray(Simulation):
 
     def eval(self, inputs):
         """
-        evaluates a given list of challenges regarding bias
-        :param inputs: list of challenges
-        :return: list of responses
+        evaluates a given array of challenges regarding bias
+        :param inputs: array of challenges
+        :return: array of responses
         """
         if self.bias:
             inputs = tools.iter_append_last(inputs, 1)
         return sign(self.val(inputs))
 
     def val(self, inputs):
+        """
+        This method evaluates a given array of challenges.
+        It composes several parts of the LTFArray simulation in order
+        to return a array of combined responses. The responses are positive and negative float values.
+        :param inputs: array of int shape(N,k,n)
+                       Array of challenges which should be evaluated by the simulation.
+        :return: array of float or int depending on the combiner shape(N)
+                 Array of responses for the N different challenges.
+        """
         return self.combiner(self.ltf_eval(self.transform(inputs, self.k)))
 
     def ltf_eval(self, inputs):
         """
-        :return: array
+        This method evaluates a given array of challenges.
+        For this purpose it uses the dot product on every challenge and weight of the weight_array.
+        :param inputs: array of int shape(N,k,n)
+                       Array of challenges which should be evaluated by the simulation.
+        :return: array of int shape(N,k,n)
+                 Array of responses for the N different challenges.
         """
         return transpose(
             array([
                 dot(
-                    inputs[:,l],
+                    inputs[:, l],
                     self.weight_array[l]
                 )
                 for l in range(self.k)
@@ -528,7 +682,7 @@ class LTFArray(Simulation):
 
 class NoisyLTFArray(LTFArray):
     """
-    Class that simulates k LTFs with n bits and a constant term each 
+    Class that simulates k LTFs with n bits and a constant term each
     with noise effect and constant bias added.
     """
 
@@ -602,7 +756,7 @@ class SimulationMajorityLTFArray(LTFArray):
 
     def val(self, inputs):
         """
-        This function a calculates the output of the LTFArray based on weights with majority vote. 
+        This function a calculates the output of the LTFArray based on weights with majority vote.
         :param inputs: array of int shape(N,k,n)
                        Array of challenges which should be evaluated by the simulation.
         :return: array of int shape(N)
@@ -622,5 +776,5 @@ class SimulationMajorityLTFArray(LTFArray):
         noise = self.random.normal(loc=0,
                                    scale=self.sigma_noise,
                                    size=(self.vote_count, len(transformed_inputs), self.k))
-        responses = sign(sum(sign(evaled_inputs + noise), 0))
+        responses = sign(np_sum(sign(evaled_inputs + noise), 0))
         return responses

--- a/pypuf/simulation/base.py
+++ b/pypuf/simulation/base.py
@@ -1,8 +1,23 @@
+"""
+This module provides an abstract class which defines an interface which an simulation have to implement in order to
+interact with other classes in this project.
+"""
 import abc
 
 
 class Simulation(object, metaclass=abc.ABCMeta):
-
+    """
+    This class is an interface which an simulation must implement in order to be compatible to other classes especially
+    learner. This interface is designed to be used with challenge response simulations. A simulation gets some
+    challenges as input in order to evaluate them. The return values of the evaluation are the responses of the PUF.
+    """
     @abc.abstractmethod
     def eval(self, inputs):
+        """
+        This is the function which evaluates the PUF simulation.
+        :param inputs: the type is not so strict and depends on the implementation
+                       Input challenges
+        :return the type is not so strict and depends on the implementation
+                Response of the PUF simulation
+        """
         raise NotImplementedError('users must define learn to use this base class')

--- a/pypuf/simulation/fourier_based/fourier_expansion.py
+++ b/pypuf/simulation/fourier_based/fourier_expansion.py
@@ -1,9 +1,18 @@
+# TODO REMOVE THIS EXCEPTION!
+# pylint: disable-msg=C0103
+"""
+This module provides an model to simulate a PUF based on fourier coefficients.
+"""
 from pypuf.simulation.base import Simulation
 from pypuf import tools
 import numpy as np
 
 
 class FourierCoefficient:
+    """
+    TODO write a doc string
+    FourierCoefficient
+    """
     def __init__(self, s, val):
         self.s = s
         self.val = val
@@ -17,10 +26,18 @@ class FourierExpansion(Simulation):
     """
 
     def __init__(self, fourier_coefficients):
+        """
+        TODO write a doc string
+        __init__
+        """
         self.fourier_coefficients = fourier_coefficients
         self.n = len(fourier_coefficients[0].s)
 
     def eval(self, inputs):
+        """
+        TODO write a doc string
+        eval
+        """
         vals = np.array(
             [coefficient.val * tools.chi_vectorized(coefficient.s, inputs)
              for coefficient in self.fourier_coefficients]
@@ -35,7 +52,15 @@ class FourierExpansionSign(FourierExpansion):
     """
 
     def eval(self, inputs):
+        """
+        TODO write a doc string
+        eval
+        """
         return np.sign(super(FourierExpansionSign, self).eval(inputs))
 
     def val(self, inputs):
+        """
+        TODO write a doc string
+        val
+        """
         return super(FourierExpansionSign, self).eval(inputs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy
 scipy
 polymath
+pylint

--- a/sim_learn.py
+++ b/sim_learn.py
@@ -1,18 +1,75 @@
+"""
+This module is a command line tool which provides an interface for experiments which are designed to learn an arbiter
+PUF LTFarray simulation with the logistic regression learning algorithm. If you want to use this tool you will have to
+define nine parameters which define the experiment.
+
+Example usage "python sim_learn.py n k transformation combiner N restarts instances seed_instance seed_model"
+
+n: int
+          Number of stages of a PUF
+k: int
+          Number of PUFs which are involved
+transformation: string
+                Name of the transformation which is used to transform input before it is used in LTFs
+                    - id  -- does nothing at all
+                    - atf -- convert according to "natural" Arbiter chain
+                             implementation
+                    - mm  -- designed to achieve maximum PTF expansion length
+                             only implemented for k=2 and even n
+                    - lightweight_secure -- design by Majzoobi et al. 2008
+                                            only implemented for even n
+                    - shift_lightweight_secure -- design like Majzoobi
+                                                  et al. 2008, but with the shift
+                                                  operation executed first
+                                                  only implemented for even n
+                    - soelter_lightweight_secure -- design like Majzoobi
+                                                    et al. 2008, but one bit different
+                                                    only implemented for even n
+                    - 1_n_bent -- one LTF gets "bent" input, the others id
+                    - 1_1_bent -- one bit gets "bent" input, the others id,
+                                  this is proven to have maximum PTF
+                                  length for the model
+                    - polynomial -- challenges are interpreted as polynomials
+                                    from GF(2^64). From the initial challenge c,
+                                    the i-th Arbiter chain gets the coefficients
+                                    of the polynomial c^(i+1) as challenge.
+                                    For now only challenges with length n=64 are accepted.
+
+combiner: string
+          Name of the combiner function which is used to combine the output bits to a single bit
+            - xor     -- output the parity of all output bits
+            - ip_mod2 -- output the inner product mod 2 of all output
+N: int
+   Number of challenges
+restarts: int or float
+          Number of repeated initializations of the learner
+          Use a float number x, 0<x<1 to repeat learning until given accuracy.
+instances: int
+           Number of repeated initializations the instance
+           The number total learning attempts is restarts*instances.
+seed_instance: int
+               Random seed used for LTF array instance
+seed_model: int
+            Random seed used for the model in first learning attempt
+"""
+import time
+from sys import argv, stderr
 from numpy import amin, amax, mean, array, append
 from numpy.random import RandomState
 from pypuf.learner.regression.logistic_regression import LogisticRegression
 from pypuf.simulation.arbiter_based.ltfarray import LTFArray
 from pypuf import tools
-import time
-from sys import argv, stdout, stderr
 
 
 def main(args):
-
+    """
+    This method includes the main functionality of the module it parses the argument vector and executes the learning
+    attempts on the PUF instances.
+    """
     if len(args) != 10:
         stderr.write('LTF Array Simulator and Logistic Regression Learner\n')
         stderr.write('Usage:\n')
-        stderr.write('sim_learn.py n k transformation combiner N restarts seed_instance seed_model\n')
+        stderr.write('sim_learn.py n k transformation combiner N restarts instances seed_instance seed_model\n')
         stderr.write('               n: number of bits per Arbiter chain\n')
         stderr.write('               k: number of Arbiter chains\n')
         stderr.write('  transformation: used to transform input before it is used in LTFs\n')
@@ -40,7 +97,8 @@ def main(args):
         stderr.write('                                  the i-th Arbiter chain gets the coefficients \n')
         stderr.write('                                  of the polynomial c^(i+1) as challenge.\n')
         stderr.write('                                  For now only challenges with length n=64 are accepted.\n')
-        stderr.write('                  - permutation_atf -- for each Arbiter chain first a pseudorandom permutation \n')
+        stderr.write(
+            '                  - permutation_atf -- for each Arbiter chain first a pseudorandom permutation \n')
         stderr.write('                                       is applied and thereafter the ATF transform.\n')
         stderr.write('                  - random -- Each Arbiter chain gets a random challenge derived from the\n')
         stderr.write('                              original challenge using a PRNG.\n')
@@ -107,7 +165,7 @@ def main(args):
     training_times = array([])
     iterations = array([])
 
-    for j in range(instances):
+    for _ in range(instances):
 
         stderr.write('----------- Choosing new instance. ---------\n')
 
@@ -130,7 +188,7 @@ def main(args):
         dist = 1
 
         while i < restarts and 1 - dist < convergence:
-            stderr.write('\r%5i/%5i         ' % (i+1, restarts if restarts < float('inf') else 0))
+            stderr.write('\r%5i/%5i         ' % (i + 1, restarts if restarts < float('inf') else 0))
             start = time.time()
             model = lr_learner.learn()
             end = time.time()
@@ -155,9 +213,9 @@ def main(args):
                     '%1.5f' % (1 - dist),
                 ]
             ) + '\n')
-            #stderr.write('training time:                % 5.3fs' % (end - start))
-            #stderr.write('min training distance:        % 5.3f' % lr_learner.min_distance)
-            #stderr.write('test distance (1000 samples): % 5.3f\n' % dist)
+            # stderr.write('training time:                % 5.3fs' % (end - start))
+            # stderr.write('min training distance:        % 5.3f' % lr_learner.min_distance)
+            # stderr.write('test distance (1000 samples): % 5.3f\n' % dist)
             i += 1
 
     stderr.write('\r              \r')
@@ -167,9 +225,9 @@ def main(args):
     stderr.write('test accuracy: %s\n' % accuracy)
     stderr.write('\n\n')
     stderr.write('min/avg/max training time  : % 9.3fs /% 9.3fs /% 9.3fs\n' % (
-    amin(training_times), mean(training_times), amax(training_times)))
+        amin(training_times), mean(training_times), amax(training_times)))
     stderr.write('min/avg/max iteration count: % 9.3f  /% 9.3f  /% 9.3f \n' % (
-    amin(iterations), mean(iterations), amax(iterations)))
+        amin(iterations), mean(iterations), amax(iterations)))
     stderr.write(
         'min/avg/max test accuracy  : % 9.3f  /% 9.3f  /% 9.3f \n' % (amin(accuracy), mean(accuracy), amax(accuracy)))
     stderr.write('\n\n')

--- a/stability_calculation.py
+++ b/stability_calculation.py
@@ -1,15 +1,19 @@
+"""
+This module provides the ability to calculate a list of stabilities for randomly chosen challenges of randomly chosen
+MV XOR Arbiter PUF.
+"""
+from sys import argv, stderr
 from pypuf.simulation.arbiter_based.ltfarray import LTFArray, SimulationMajorityLTFArray, NoisyLTFArray
 from pypuf import tools
 from numpy.random import RandomState
-from sys import argv, stderr
 
 
-def stability_figure_data(n, k, r, sigma_noise_ratio, num, reps, random):
+def stability_figure_data(n, k, vote_count, sigma_noise_ratio, num, reps, random):
     """
     Returns a list of stabilities for randomly chosen challenges of randomly chosen MV XOR Arbiter PUF.
     :param n: Length of arbiter chains
     :param k: Number of arbiter chains
-    :param r: Number of votes for each chain
+    :param vote_count: Number of votes for each chain
     :param sigma_noise_ratio: sigma_noise to sigma_model ratio of the arbiter chains
     :param num: number of challenges to compute stability for
     :param reps: number of samples per challenge to base the stability computation on
@@ -23,7 +27,7 @@ def stability_figure_data(n, k, r, sigma_noise_ratio, num, reps, random):
                                              LTFArray.combiner_xor,
                                              sigma_noise,
                                              random_instance_noise=random,
-                                             vote_count=r)
+                                             vote_count=vote_count)
 
     stabilities = tools.approx_stabilities(instance_mv, num, reps, random)
     print('{' + ','.join(map(str, stabilities)) + '}')

--- a/stability_calculation.py
+++ b/stability_calculation.py
@@ -18,7 +18,6 @@ def stability_figure_data(n, k, vote_count, sigma_noise_ratio, num, reps, random
     :param num: number of challenges to compute stability for
     :param reps: number of samples per challenge to base the stability computation on
     :param random: random seed for all PRNG used here
-    :return:
     """
     sigma_noise = NoisyLTFArray.sigma_noise_from_random_weights(n, 1, sigma_noise_ratio)
     weights = LTFArray.normal_weights(n, k, random_instance=random)

--- a/test/test_experiment.py
+++ b/test/test_experiment.py
@@ -1,3 +1,4 @@
+"""This module tests the different experiment classes."""
 import unittest
 import os
 import glob
@@ -9,21 +10,31 @@ from pypuf.experiments.experiment.majority_vote import ExperimentMajorityVoteFin
 
 
 class TestBase(unittest.TestCase):
+    """
+    Every experiment needs logs in order to work. This class is used to delete all logs before after an experiment
+    test."
+    """
     def setUp(self):
         # Remove all log files
         paths = list(glob.glob('*.log'))
-        for p in paths:
-            os.remove(p)
+        for path in paths:
+            os.remove(path)
 
     def tearDown(self):
         # Remove all log files
         paths = list(glob.glob('*.log'))
-        for p in paths:
-            os.remove(p)
+        for path in paths:
+            os.remove(path)
 
 
 class TestExperimentLogisticRegression(TestBase):
+    """
+    This class tests the logistic regression experiment.
+    """
     def test_run_and_analyze(self):
+        """
+        This method only runs the experiment.
+        """
         logger_name = 'log'
 
         # Setup multiprocessing logging
@@ -32,16 +43,24 @@ class TestExperimentLogisticRegression(TestBase):
                                            args=(queue, setup_logger, logger_name,))
         listener.start()
 
-        self.lr16_4 = ExperimentLogisticRegression('exp1', 8, 2, 2 ** 8, 0xbeef, 0xbeef, LTFArray.transform_id,
-                                                   LTFArray.combiner_xor)
-        self.lr16_4.execute(queue, logger_name)
+        lr16_4 = ExperimentLogisticRegression('exp1', 8, 2, 2 ** 8, 0xbeef, 0xbeef, LTFArray.transform_id,
+                                              LTFArray.combiner_xor)
+        lr16_4.execute(queue, logger_name)
 
         queue.put_nowait(None)
         listener.join()
 
 
 class TestExperimentMajorityVoteFindVotes(unittest.TestCase):
+    """
+    This class is used to test the Experiment which searches for a number of votes which is needed to achieve an
+    overall desired stability.
+    """
     def test_run_and_analyze(self):
+        """
+        This method run the experiment and checks if a number of votes was found in oder to satisfy an
+        overall desired stability.
+        """
         logger_name = 'log'
 
         # Setup multiprocessing logging

--- a/test/test_experimenter.py
+++ b/test/test_experimenter.py
@@ -1,3 +1,4 @@
+"""This module test the experimenter class which is used to distribute experiments over several cores."""
 import unittest
 import os
 import glob
@@ -9,19 +10,23 @@ from pypuf.experiments.experimenter import Experimenter
 
 
 class TestExperimenter(unittest.TestCase):
+    """
+    This class is used to test the experimenter class.
+    """
     def setUp(self):
         # Remove all log files
         paths = list(glob.glob('*.log'))
-        for p in paths:
-            os.remove(p)
+        for path in paths:
+            os.remove(path)
 
     def tearDown(self):
         # Remove all log files
         paths = list(glob.glob('*.log'))
-        for p in paths:
-            os.remove(p)
+        for path in paths:
+            os.remove(path)
 
     def test_lr_experiments(self):
+        """This method runs the experimenter for four logistic regression experiments."""
         lr16_4_1 = ExperimentLogisticRegression('test_lr_experiments1', 8, 2, 2 ** 8, 0xbeef, 0xbeef,
                                                 LTFArray.transform_id,
                                                 LTFArray.combiner_xor)
@@ -42,6 +47,7 @@ class TestExperimenter(unittest.TestCase):
         experimenter.run()
 
     def test_mv_experiments(self):
+        """This method runs the experimenter with five ExperimentMajorityVoteFindVotes experiments."""
         experiments = []
         for i in range(5):
             n = 8
@@ -132,13 +138,13 @@ class TestExperimenter(unittest.TestCase):
 
     def test_file_handle(self):
         """
-        This test check if process file handles are deleted. Some Systems have have limit of open file handles. 
-        :return: 
+        This test check if process file handles are deleted. Some Systems have have limit of open file handles.
         """
         class ExperimentDummy(Experiment):
-            def __init__(self, log_name):
-                super().__init__(log_name)
-
+            """
+            This is an empty experiment class which can be used to run a huge amount of experiments with an
+            experimenter.
+            """
             def run(self):
                 pass
 

--- a/test/test_logistic_regression.py
+++ b/test/test_logistic_regression.py
@@ -1,3 +1,4 @@
+"""This module tests the logistic regression learner."""
 import unittest
 from numpy.random import RandomState
 from pypuf.simulation.arbiter_based.ltfarray import LTFArray
@@ -7,7 +8,7 @@ from pypuf.tools import TrainingSet
 
 class TestLogisticRegression(unittest.TestCase):
     """
-        This module tests the logistic regression learner.
+    This module tests the logistic regression learner.
     """
     n = 8
     k = 2
@@ -17,7 +18,7 @@ class TestLogisticRegression(unittest.TestCase):
 
     def test_learn_xor(self):
         """"
-            Stupid test which gains code coverage
+        Stupid test which gains code coverage
         """
         instance_prng = RandomState(seed=TestLogisticRegression.seed_instance)
         model_prng = RandomState(seed=TestLogisticRegression.seed_model)
@@ -44,7 +45,7 @@ class TestLogisticRegression(unittest.TestCase):
 
     def test_learn_ip_mod2(self):
         """"
-            Stupid test which gains code coverage
+        Stupid test which gains code coverage
         """
         instance_prng = RandomState(seed=TestLogisticRegression.seed_instance)
         model_prng = RandomState(seed=TestLogisticRegression.seed_model)

--- a/test/test_low_degree.py
+++ b/test/test_low_degree.py
@@ -1,3 +1,6 @@
+"""
+This module tests the low degree learner.
+"""
 import unittest
 from numpy.random import RandomState
 from pypuf.simulation.arbiter_based.ltfarray import LTFArray
@@ -7,7 +10,7 @@ from pypuf.tools import TrainingSet
 
 class TestLowDegree(unittest.TestCase):
     """
-        This module tests the low degree learner.
+    This module tests the low degree learner.
     """
     n = 8
     k = 2
@@ -17,7 +20,7 @@ class TestLowDegree(unittest.TestCase):
 
     def test_learn_xor(self):
         """"
-            Stupid test which gains code coverage
+        Stupid test which gains code coverage
         """
         instance_prng = RandomState(seed=TestLowDegree.seed_instance)
 

--- a/test/test_mv_num_of_votes.py
+++ b/test/test_mv_num_of_votes.py
@@ -1,10 +1,19 @@
+"""
+This module is used to test the command line tool which searches the number of votes for several instances of
+SimulationMajorityLTFArrays in order to satisfy a overall desired stability.
+"""
 import unittest
 import mv_num_of_votes
 
 
 class TestMvNumOfVotes(unittest.TestCase):
+    """This class is used to test the mv_num_of_votes commandline tool"""
 
     def test_8_1_puf(self):
+        """
+        This method checks the output log of mv_num_of_votes for a stability greater equal the
+        overall_desired_stability.
+        """
         overall_desired_stability = 0.8
         mv_num_of_votes.main(["0.95", str(overall_desired_stability), "8", "1", "1", "0.33", "250", "1"])
 
@@ -17,4 +26,4 @@ class TestMvNumOfVotes(unittest.TestCase):
                 break
 
         # if the line is '' then no stability where found which satisfy overall_desired_stability
-        self.assertNotEquals(line, '')
+        self.assertNotEqual(line, '', 'stability where found which satisfy overall_desired_stability')

--- a/test/test_sim_learn.py
+++ b/test/test_sim_learn.py
@@ -1,48 +1,64 @@
+"""This module tests the sim_learn command line script."""
 import unittest
 import sim_learn
 
 
 class TestSimLearn(unittest.TestCase):
+    """
+    This class is used to test different parameters for the sim_learn module.
+    """
     def test_id(self):
+        """This tests the id transformation and xor combiner."""
         sim_learn.main(["sim_learn", "8", "2", "id", "xor", "20", "1", "2", "1234", "1234"])
 
     def test_atf(self):
+        """This tests the atf transformation and xor combiner."""
         sim_learn.main(["sim_learn", "8", "2", "atf", "xor", "20", "1", "2", "1234", "1234"])
 
     def test_mm(self):
+        """This tests the mm transformation and xor combiner."""
         sim_learn.main(["sim_learn", "8", "2", "mm", "xor", "20", "1", "2", "1234", "1234"])
 
     def test_lightweight_secure(self):
+        """This tests the lightweight secure transformation and xor combiner."""
         sim_learn.main(["sim_learn", "8", "2", "lightweight_secure", "xor", "20", "1", "2", "1234", "1234"])
 
     def test_lightweight_secure_original(self):
+        """This tests the lightweight secure original transformation and xor combiner."""
         sim_learn.main(["sim_learn", "8", "2", "lightweight_secure_original", "xor", "20", "1", "2", "1234", "1234"])
 
     def test_1_n_bent(self):
+        """This tests the one to n bent transformation and xor combiner."""
         sim_learn.main(["sim_learn", "8", "2", "1_n_bent", "xor", "20", "1", "2", "1234", "1234"])
 
     def test_1_1_bent(self):
+        """This tests the one to one bent transformation and xor combiner."""
         sim_learn.main(["sim_learn", "8", "2", "1_1_bent", "xor", "20", "1", "2", "1234", "1234"])
 
     def test_ip_mod2_id(self):
+        """This tests the identity transformation and inner product mod 2 combiner."""
         sim_learn.main(["sim_learn", "8", "2", "id", "ip_mod2", "20", "1", "2", "1234", "1234"])
 
     def test_ip_mod2_atf(self):
+        """This tests the atf transformation and inner product mod 2 combiner."""
         sim_learn.main(["sim_learn", "8", "2", "atf", "ip_mod2", "20", "1", "2", "1234", "1234"])
 
     def test_ip_mod2_mm(self):
+        """This tests the mm transformation and inner product mod 2 combiner."""
         sim_learn.main(["sim_learn", "8", "2", "mm", "ip_mod2", "20", "1", "2", "1234", "1234"])
 
     def test_ip_mod2_lightweight_secure(self):
+        """This tests the lightweight secure transformation and inner product mod 2 combiner."""
         sim_learn.main(["sim_learn", "8", "2", "lightweight_secure", "ip_mod2", "20", "1", "2", "1234", "1234"])
 
     def test_ip_mod2_1_n_bent(self):
+        """This tests the one to n bent transformation and inner product mod 2 combiner."""
         sim_learn.main(["sim_learn", "8", "2", "1_n_bent", "ip_mod2", "20", "1", "2", "1234", "1234"])
 
     def test_ip_mod2_1_1_bent(self):
+        """This tests the one to one bent transformation and inner product mod 2 combiner."""
         sim_learn.main(["sim_learn", "8", "2", "1_1_bent", "ip_mod2", "20", "1", "2", "1234", "1234"])
 
     def test_permutation_atf(self):
+        """This tests the atf permutation transformation and xor combiner."""
         sim_learn.main(["sim_learn", "8", "2", "permutation_atf", "xor", "10", "1", "2", "1234", "1234"])
-
-

--- a/test/test_simulation.py
+++ b/test/test_simulation.py
@@ -282,7 +282,7 @@ class TestInputTransformation(unittest.TestCase):
         assert_array_equal(
             LTFArray.generate_stacked_transform(
                 transform_1=LTFArray.transform_id,
-                kk=2,
+                puf_count=2,
                 transform_2=LTFArray.transform_shift
             )(test_array, k=4),
             [
@@ -310,8 +310,8 @@ class TestInputTransformation(unittest.TestCase):
         assert_array_equal(
             LTFArray.generate_random_permutation_transform(
                 seed=0xbeef,
-                nn=4,
-                kk=3,
+                challenge_length=4,
+                puf_count=3,
             )(test_array, k=3),
             [
                 [
@@ -329,8 +329,8 @@ class TestInputTransformation(unittest.TestCase):
         assert_array_equal(
             LTFArray.generate_random_permutation_transform(
                 seed=0xbeef,
-                nn=4,
-                kk=3,
+                challenge_length=4,
+                puf_count=3,
                 atf=True,
             )(test_array, k=3),
             [
@@ -357,7 +357,7 @@ class TestInputTransformation(unittest.TestCase):
         assert_array_equal(
             LTFArray.generate_concatenated_transform(
                 transform_1=LTFArray.transform_1_n_bent,
-                nn=6,
+                bit_number_transform_1=6,
                 transform_2=LTFArray.transform_id,
             )(test_array, k=3),
             [

--- a/test/test_simulation.py
+++ b/test/test_simulation.py
@@ -1,3 +1,7 @@
+"""
+This module is used to test the different simulation models.
+"""
+
 import unittest
 from pypuf.simulation.arbiter_based.ltfarray import LTFArray, NoisyLTFArray, SimulationMajorityLTFArray
 from pypuf import tools
@@ -7,14 +11,15 @@ from numpy.random import RandomState
 
 
 class TestCombiner(unittest.TestCase):
-
+    """This class tests the different combiner functions with predefined input and outputs."""
     def test_combine_xor(self):
+        """This function tests the xor combiner function with one pair of input and output."""
         assert_array_equal(
             LTFArray.combiner_xor(
                 [
-                    [ 1,  1, -3,  1],
-                    [-1, -1, -1,  1],
-                    [-2, -2,  2,  1]
+                    [1, 1, -3, 1],
+                    [-1, -1, -1, 1],
+                    [-2, -2, 2, 1]
                 ]
             ),
             [
@@ -25,6 +30,7 @@ class TestCombiner(unittest.TestCase):
         )
 
     def test_combine_ip_mod2(self):
+        """This function tests the inner product mod 2 combiner function with two pairs of input and output."""
         assert_array_equal(
             LTFArray.combiner_ip_mod2(
                 array([
@@ -56,110 +62,116 @@ class TestCombiner(unittest.TestCase):
 
 
 class TestInputTransformation(unittest.TestCase):
-
+    """This class tests the different functions used to transform the input of a LTFArray simulation."""
     def test_id(self):
-        test_cs = [
+        """
+        This method test the identity function for the predefined inputs (challenges). If every challenge is duplicated
+        k times the function works correct.
+        """
+        test_challnges = [
             [
-                [-1,  1,  1, -1, -1],
+                [-1, 1, 1, -1, -1],
                 [-1, -1, -1, -1, -1],
-                [ 1,  1, -1, -1, -1],
+                [1, 1, -1, -1, -1],
             ],
             [
-                [ 1,  1,  1, -1, -1],
+                [1, 1, 1, -1, -1],
                 [-1, -1, -1, -1, -1],
-                [-1,  1, -1, -1, -1],
+                [-1, 1, -1, -1, -1],
             ],
             [
-                [-1,  1,  1, -1, -1],
+                [-1, 1, 1, -1, -1],
                 [-1, -1, -1, -1, -1],
-                [-1,  1, -1, -1, -1],
+                [-1, 1, -1, -1, -1],
             ]
         ]
-        for cs in test_cs:
+        for challenges in test_challnges:
             assert_array_equal(
-                LTFArray.transform_id(cs, k=4),
+                LTFArray.transform_id(challenges, k=4),
                 [
                     [
-                        cs[0],
-                        cs[0],
-                        cs[0],
-                        cs[0]
+                        challenges[0],
+                        challenges[0],
+                        challenges[0],
+                        challenges[0]
                     ],
                     [
-                        cs[1],
-                        cs[1],
-                        cs[1],
-                        cs[1]
+                        challenges[1],
+                        challenges[1],
+                        challenges[1],
+                        challenges[1]
                     ],
                     [
-                        cs[2],
-                        cs[2],
-                        cs[2],
-                        cs[2]
+                        challenges[2],
+                        challenges[2],
+                        challenges[2],
+                        challenges[2]
                     ]
                 ]
             )
 
     def test_atf(self):
+        """This method tests the atf transformation with predefined input and output."""
         test_array = array([
-                [-1,  1,  1, -1, -1],
-                [-1, -1, -1, -1, -1],
-                [ 1,  1, -1, -1, -1],
-                [ 1,  1,  1, -1, -1],
-                [-1, -1, -1, -1, -1],
-                [-1,  1, -1, -1, -1],
+            [-1, 1, 1, -1, -1],
+            [-1, -1, -1, -1, -1],
+            [1, 1, -1, -1, -1],
+            [1, 1, 1, -1, -1],
+            [-1, -1, -1, -1, -1],
+            [-1, 1, -1, -1, -1],
         ])
         assert_array_equal(
             LTFArray.transform_atf(test_array, k=3),
             [
                 [
-                    [-1,  1,  1,  1, -1],
-                    [-1,  1,  1,  1, -1],
-                    [-1,  1,  1,  1, -1],
+                    [-1, 1, 1, 1, -1],
+                    [-1, 1, 1, 1, -1],
+                    [-1, 1, 1, 1, -1],
                 ],
                 [
-                    [-1,  1, -1,  1, -1],
-                    [-1,  1, -1,  1, -1],
-                    [-1,  1, -1,  1, -1],
+                    [-1, 1, -1, 1, -1],
+                    [-1, 1, -1, 1, -1],
+                    [-1, 1, -1, 1, -1],
                 ],
                 [
-                    [-1, -1, -1,  1, -1],
-                    [-1, -1, -1,  1, -1],
-                    [-1, -1, -1,  1, -1],
+                    [-1, -1, -1, 1, -1],
+                    [-1, -1, -1, 1, -1],
+                    [-1, -1, -1, 1, -1],
                 ],
                 [
-                    [ 1,  1,  1,  1, -1],
-                    [ 1,  1,  1,  1, -1],
-                    [ 1,  1,  1,  1, -1],
+                    [1, 1, 1, 1, -1],
+                    [1, 1, 1, 1, -1],
+                    [1, 1, 1, 1, -1],
                 ],
                 [
-                    [-1,  1, -1,  1, -1],
-                    [-1,  1, -1,  1, -1],
-                    [-1,  1, -1,  1, -1],
+                    [-1, 1, -1, 1, -1],
+                    [-1, 1, -1, 1, -1],
+                    [-1, 1, -1, 1, -1],
                 ],
                 [
-                    [ 1, -1, -1,  1, -1],
-                    [ 1, -1, -1,  1, -1],
-                    [ 1, -1, -1,  1, -1],
+                    [1, -1, -1, 1, -1],
+                    [1, -1, -1, 1, -1],
+                    [1, -1, -1, 1, -1],
                 ]
             ]
         )
 
     def test_shift(self):
+        """This method tests the shift transformation with predefined input and output."""
         test_array = array([
-                [-1,  1,  1, -1, -1],
-                [-1, -1, -1, -1, -1],
-                [ 1,  1, -1, -1, -1],
-                [ 1,  1, -1, -1, -1],
-                [ 1,  2,  3,  4,  5],
+            [-1, 1, 1, -1, -1],
+            [-1, -1, -1, -1, -1],
+            [1, 1, -1, -1, -1],
+            [1, 1, -1, -1, -1],
+            [1, 2, 3, 4, 5],
         ])
         assert_array_equal(
             LTFArray.transform_shift(test_array, k=3),
             [
                 [
-                    [-1,  1,  1, -1, -1],
-                    [ 1,  1, -1, -1, -1],
-                    [ 1, -1, -1, -1,  1],
+                    [-1, 1, 1, -1, -1],
+                    [1, 1, -1, -1, -1],
+                    [1, -1, -1, -1, 1],
                 ],
                 [
                     [-1, -1, -1, -1, -1],
@@ -167,14 +179,14 @@ class TestInputTransformation(unittest.TestCase):
                     [-1, -1, -1, -1, -1],
                 ],
                 [
-                    [ 1,  1, -1, -1, -1],
-                    [ 1, -1, -1, -1,  1],
-                    [-1, -1, -1,  1,  1],
+                    [1, 1, -1, -1, -1],
+                    [1, -1, -1, -1, 1],
+                    [-1, -1, -1, 1, 1],
                 ],
                 [
-                    [ 1,  1, -1, -1, -1],
-                    [ 1, -1, -1, -1,  1],
-                    [-1, -1, -1,  1,  1],
+                    [1, 1, -1, -1, -1],
+                    [1, -1, -1, -1, 1],
+                    [-1, -1, -1, 1, 1],
                 ],
                 [
                     [1, 2, 3, 4, 5],
@@ -185,78 +197,84 @@ class TestInputTransformation(unittest.TestCase):
         )
 
     def test_secure_lightweight(self):
+        """This method tests the secure lightweight transformation with predefined input and output."""
         test_array = array([
-            [ 1, -1, -1,  1, -1,  1],
-            [-1,  1,  1, -1, -1,  1],
+            [1, -1, -1, 1, -1, 1],
+            [-1, 1, 1, -1, -1, 1],
         ])
         assert_array_equal(
             LTFArray.transform_lightweight_secure(test_array, k=3),
             [
                 [
-                    [-1, -1, -1,  1,  1, -1],
-                    [-1, -1,  1,  1, -1, -1],
-                    [-1,  1,  1, -1, -1, -1],
+                    [-1, -1, -1, 1, 1, -1],
+                    [-1, -1, 1, 1, -1, -1],
+                    [-1, 1, 1, -1, -1, -1],
                 ],
                 [
-                    [-1, -1, -1, -1,  1,  1],
-                    [-1, -1, -1,  1,  1, -1],
-                    [-1, -1,  1,  1, -1, -1],
+                    [-1, -1, -1, -1, 1, 1],
+                    [-1, -1, -1, 1, 1, -1],
+                    [-1, -1, 1, 1, -1, -1],
                 ],
             ]
         )
 
     def test_shift_secure_lightweight(self):
+        """This method tests the shift secure lightweight transformation with predefined input and output."""
         test_array = array([
-            [ 1, -1, -1,  1, -1,  1],
+            [1, -1, -1, 1, -1, 1],
         ])
         assert_array_equal(
             LTFArray.transform_shift_lightweight_secure(test_array, k=3),
             [
                 [
-                    [-1, -1, -1,  1,  1, -1],
-                    [ 1, -1,  1, -1, -1, -1],
-                    [-1, -1, -1, -1, -1,  1],
+                    [-1, -1, -1, 1, 1, -1],
+                    [1, -1, 1, -1, -1, -1],
+                    [-1, -1, -1, -1, -1, 1],
                 ],
             ]
         )
 
     def test_1_n_bent(self):
+        """This method tests the one to n bent transformation with predefined inputs and outputs."""
         test_array = array([
-            [ 1, -1, -1,  1, -1,  1],
-            [-1,  1,  1, -1, -1,  1],
+            [1, -1, -1, 1, -1, 1],
+            [-1, 1, 1, -1, -1, 1],
         ])
         assert_array_equal(
             LTFArray.transform_1_n_bent(test_array, k=3),
             [
                 [
-                    [ 1, -1,  1, -1,  1, -1],
-                    [ 1, -1, -1,  1, -1,  1],
-                    [ 1, -1, -1,  1, -1,  1],
+                    [1, -1, 1, -1, 1, -1],
+                    [1, -1, -1, 1, -1, 1],
+                    [1, -1, -1, 1, -1, 1],
                 ],
                 [
-                    [ 1, -1,  1, -1,  1, -1],
-                    [-1,  1,  1, -1, -1,  1],
-                    [-1,  1,  1, -1, -1,  1],
+                    [1, -1, 1, -1, 1, -1],
+                    [-1, 1, 1, -1, -1, 1],
+                    [-1, 1, 1, -1, -1, 1],
                 ],
             ]
         )
         test_array = array([
-            [ 1, -1, -1,  1, -1,  1],
-            [-1,  1,  1, -1, -1,  1],
+            [1, -1, -1, 1, -1, 1],
+            [-1, 1, 1, -1, -1, 1],
         ])
         assert_array_equal(
             LTFArray.transform_1_n_bent(test_array, k=1),
             [
                 [
-                    [ 1, -1,  1, -1,  1, -1],
+                    [1, -1, 1, -1, 1, -1],
                 ],
                 [
-                    [ 1, -1,  1, -1,  1, -1],
+                    [1, -1, 1, -1, 1, -1],
                 ],
             ]
         )
 
-    def test_transform_stack(self):
+    def test_generate_stacked_transform(self):
+        """
+        This method tests the stacked transformation generation of identity and shift with predefined input and output.
+        """
         test_array = array([
             [1, -1, 1, -1],
             [-1, -1, 1, -1],
@@ -283,10 +301,11 @@ class TestInputTransformation(unittest.TestCase):
             ]
         )
 
-    def test_transform_permutations(self):
+    def test_generate_random_permutations(self):
+        """This method tests the random permutation transformation generation ith predefined inputs and outputs."""
         test_array = array([
-            [1,2,3,4],
-            [10,20,30,40],
+            [1, 2, 3, 4],
+            [10, 20, 30, 40],
         ])
         assert_array_equal(
             LTFArray.generate_random_permutation_transform(
@@ -316,21 +335,24 @@ class TestInputTransformation(unittest.TestCase):
             )(test_array, k=3),
             [
                 [
-                    [4*1*2*3, 1*2*3, 2*3, 3],
-                    [1*4*3*2, 4*3*2, 3*2, 2],
-                    [3*1*4*2, 1*4*2, 4*2, 2],
+                    [4 * 1 * 2 * 3, 1 * 2 * 3, 2 * 3, 3],
+                    [1 * 4 * 3 * 2, 4 * 3 * 2, 3 * 2, 2],
+                    [3 * 1 * 4 * 2, 1 * 4 * 2, 4 * 2, 2],
                 ],
                 [
-                    [40*10*20*30, 10*20*30, 20*30, 30],
-                    [10*40*30*20, 40*30*20, 30*20, 20],
-                    [30*10*40*20, 10*40*20, 40*20, 20],
+                    [40 * 10 * 20 * 30, 10 * 20 * 30, 20 * 30, 30],
+                    [10 * 40 * 30 * 20, 40 * 30 * 20, 30 * 20, 20],
+                    [30 * 10 * 40 * 20, 10 * 40 * 20, 40 * 20, 20],
                 ],
             ],
         )
 
-    def test_transform_concat(self):
+    def test_generate_concatenated_transform(self):
+        """
+        This method tests the concatenation of 1 to n bent and identity transformation with predefined input and output.
+        """
         test_array = array([
-            [ 1, -1, -1,  1, -1,  1, -1,  1,  1, -1, -1],
+            [1, -1, -1, 1, -1, 1, -1, 1, 1, -1, -1],
         ])
         assert_array_equal(
             LTFArray.generate_concatenated_transform(
@@ -340,41 +362,42 @@ class TestInputTransformation(unittest.TestCase):
             )(test_array, k=3),
             [
                 [
-                    [ 1, -1,  1, -1,  1, -1, -1,  1,  1, -1, -1],
-                    [ 1, -1, -1,  1, -1,  1, -1,  1,  1, -1, -1],
-                    [ 1, -1, -1,  1, -1,  1, -1,  1,  1, -1, -1],
+                    [1, -1, 1, -1, 1, -1, -1, 1, 1, -1, -1],
+                    [1, -1, -1, 1, -1, 1, -1, 1, 1, -1, -1],
+                    [1, -1, -1, 1, -1, 1, -1, 1, 1, -1, -1],
                 ],
             ]
         )
 
-
     def test_1_1_bent(self):
+        """This method test the one to one bent transformation with predefined input and output."""
         test_array = array([
-            [ 1, -1, -1,  1, -1,  1],
-            [-1,  1,  1, -1, -1,  1],
+            [1, -1, -1, 1, -1, 1],
+            [-1, 1, 1, -1, -1, 1],
         ])
         assert_array_equal(
             LTFArray.transform_1_1_bent(test_array, k=3),
             [
                 [
-                    [ 1, -1, -1,  1, -1,  1],
-                    [ 1, -1, -1,  1, -1,  1],
-                    [ 1, -1, -1,  1, -1,  1],
+                    [1, -1, -1, 1, -1, 1],
+                    [1, -1, -1, 1, -1, 1],
+                    [1, -1, -1, 1, -1, 1],
                 ],
                 [
-                    [ 1,  1,  1, -1, -1,  1],
-                    [-1,  1,  1, -1, -1,  1],
-                    [-1,  1,  1, -1, -1,  1],
+                    [1, 1, 1, -1, -1, 1],
+                    [-1, 1, 1, -1, -1, 1],
+                    [-1, 1, 1, -1, -1, 1],
                 ],
             ]
         )
 
     def test_polynomial(self):
+        """This method tests the polynomial transformation with predefined input and output for k=4 PUFs."""
         test_array = array([
-            [-1, -1,  1,  1,  1, -1,  1, -1, -1, -1, -1, -1, -1,  1,  1,  1,  1,
-             1,  1, -1,  1, -1, -1,  1,  1, -1,  1, -1, -1,  1, -1,  1,  1,  1,
-             1,  1, -1,  1,  1,  1,  1,  1, -1,  1,  1,  1,  1,  1, -1,  1, -1,
-             1, -1, -1, -1,  1,  1,  1, -1,  1,  1, -1,  1,  1]
+            [-1, -1, 1, 1, 1, -1, 1, -1, -1, -1, -1, -1, -1, 1, 1, 1, 1,
+             1, 1, -1, 1, -1, -1, 1, 1, -1, 1, -1, -1, 1, -1, 1, 1, 1,
+             1, 1, -1, 1, 1, 1, 1, 1, -1, 1, 1, 1, 1, 1, -1, 1, -1,
+             1, -1, -1, -1, 1, 1, 1, -1, 1, 1, -1, 1, 1]
         ])
         assert_array_equal(
             LTFArray.transform_polynomial(test_array, k=4),
@@ -397,11 +420,12 @@ class TestInputTransformation(unittest.TestCase):
         )
 
     def test_polynomial_k1(self):
+        """This method tests the polynomial transformation with predefined input and output for k=1 PUF."""
         test_array = array([
-            [-1, -1,  1,  1,  1, -1,  1, -1, -1, -1, -1, -1, -1,  1,  1,  1,  1,
-             1,  1, -1,  1, -1, -1,  1,  1, -1,  1, -1, -1,  1, -1,  1,  1,  1,
-             1,  1, -1,  1,  1,  1,  1,  1, -1,  1,  1,  1,  1,  1, -1,  1, -1,
-             1, -1, -1, -1,  1,  1,  1, -1,  1,  1, -1,  1,  1]
+            [-1, -1, 1, 1, 1, -1, 1, -1, -1, -1, -1, -1, -1, 1, 1, 1, 1,
+             1, 1, -1, 1, -1, -1, 1, 1, -1, 1, -1, -1, 1, -1, 1, 1, 1,
+             1, 1, -1, 1, 1, 1, 1, 1, -1, 1, 1, 1, 1, 1, -1, 1, -1,
+             1, -1, -1, -1, 1, 1, 1, -1, 1, 1, -1, 1, 1]
         ])
         assert_array_equal(
             LTFArray.transform_polynomial(test_array, k=1),
@@ -415,6 +439,7 @@ class TestInputTransformation(unittest.TestCase):
         )
 
     def test_permutation_atf(self):
+        """This method tests the permuation atf transformation with predefined input and output for k=4 PUFs."""
         test_array = array([
             [1, -1, -1, 1, -1, 1],
             [-1, 1, 1, -1, -1, 1],
@@ -440,7 +465,10 @@ class TestInputTransformation(unittest.TestCase):
 
 
 class TestLTFArray(unittest.TestCase):
-
+    """
+    This class is used to test the LTFArray class. For this purpose this class provides a set of instance parameter
+    in oder to test several configurations.
+    """
     test_set = [
         # n, k, mu, sigma, bias
         (64, 4, 0, 1, False),
@@ -465,29 +493,32 @@ class TestLTFArray(unittest.TestCase):
             bias = test_parameters[4]
             weight_array = LTFArray.normal_weights(n, k, mu, sigma)
 
-            input_len = n-1 if bias else n
-            inputs = RandomState(seed=0xBAADA555).choice([-1,+1], (N, input_len))  # bad ass testing
+            input_len = n - 1 if bias else n
+            inputs = RandomState(seed=0xBAADA555).choice([-1, +1], (N, input_len))  # bad ass testing
 
             biased_ltf_array = LTFArray(
-                weight_array = weight_array,
-                transform = LTFArray.transform_id,
-                combiner = LTFArray.combiner_xor,
-                bias = bias,
+                weight_array=weight_array,
+                transform=LTFArray.transform_id,
+                combiner=LTFArray.combiner_xor,
+                bias=bias,
             )
             ltf_array = LTFArray(
-                weight_array = weight_array,
-                transform = LTFArray.transform_id,
-                combiner = LTFArray.combiner_xor,
-                bias = False,
+                weight_array=weight_array,
+                transform=LTFArray.transform_id,
+                combiner=LTFArray.combiner_xor,
+                bias=False,
             )
             biased_eval = biased_ltf_array.eval(inputs)
-            inputs = tools.iter_append_last(inputs, 1)\
+            inputs = tools.iter_append_last(inputs, 1) \
                 if biased_ltf_array.bias else inputs
-            eval = ltf_array.eval(inputs)
+            ltf_array_evaled_output = ltf_array.eval(inputs)
 
-            assert_array_equal(biased_eval, eval)
+            assert_array_equal(biased_eval, ltf_array_evaled_output)
 
     def test_random_weights(self):
+        """
+        This method tests if the shape of the LTFArray generated weights are as expected.
+        """
         for test_parameters in self.test_set:
             n = test_parameters[0]
             k = test_parameters[1]
@@ -502,12 +533,12 @@ class TestLTFArray(unittest.TestCase):
 
         N = 100  # number of random inputs per test set
 
-        def ltf_eval_slow(x, w):
+        def ltf_eval_slow(challenge, weights):
             """
-            evaluate a single input x with a single ltf specified by weights w
+            evaluate a single challenge with a single ltf specified by weights
             """
-            assert len(x) == len(w)
-            return dot(x, w)
+            assert len(challenge) == len(weights)
+            return dot(challenge, weights)
 
         for test_parameters in self.test_set:
             n = test_parameters[0]
@@ -525,9 +556,9 @@ class TestLTFArray(unittest.TestCase):
 
             fast_evaluation_result = around(ltf_array.ltf_eval(LTFArray.transform_id(inputs, k)), decimals=10)
             slow_evaluation_result = []
-            for c in inputs:
+            for challenge in inputs:
                 slow_evaluation_result.append(
-                    [ltf_eval_slow(c, ltf_array.weight_array[l]) for l in range(k)]
+                    [ltf_eval_slow(challenge, ltf_array.weight_array[l]) for l in range(k)]
                 )
             slow_evaluation_result = around(slow_evaluation_result, decimals=10)
 
@@ -537,13 +568,11 @@ class TestLTFArray(unittest.TestCase):
 
 
 class TestNoisyLTFArray(TestLTFArray):
-
+    """This class is used to test the NoisyLTFArray class."""
     def test_ltf_eval(self):
         """
         Test ltf_eval for correct evaluation of LTFs.
         """
-
-        #random.normal(loc=0, scale=self.sigma_noise, size=(1, self.k))
 
         weight_prng_1 = RandomState(seed=0xBADA55)
         weight_prng_2 = RandomState(seed=0xBADA55)
@@ -559,7 +588,7 @@ class TestNoisyLTFArray(TestLTFArray):
             sigma = test_parameters[3]
 
             transformed_inputs = LTFArray.transform_id(
-                RandomState(seed=0xBAADA555).choice([-1,+1], (N, n)),  # bad ass testing
+                RandomState(seed=0xBAADA555).choice([-1, +1], (N, n)),  # bad ass testing
                 k
             )
 
@@ -570,7 +599,8 @@ class TestNoisyLTFArray(TestLTFArray):
             )
 
             noisy_ltf_array = NoisyLTFArray(
-                weight_array=LTFArray.normal_weights(n, k, mu, sigma, weight_prng_2),  # weight_prng_2 was seeded identically to weight_prng_1
+                weight_array=LTFArray.normal_weights(n, k, mu, sigma, weight_prng_2),
+                # weight_prng_2 was seeded identically to weight_prng_1
                 transform=LTFArray.transform_id,
                 combiner=LTFArray.combiner_xor,
                 sigma_noise=1,
@@ -580,13 +610,19 @@ class TestNoisyLTFArray(TestLTFArray):
             evaled_ltf_array = ltf_array.ltf_eval(transformed_inputs)
             assert_array_equal(
                 around(evaled_ltf_array + noise_prng_2.normal(loc=0, scale=1,
-                                                               size=(len(evaled_ltf_array), k)), decimals=10),
+                                                              size=(len(evaled_ltf_array), k)), decimals=10),
                 around(noisy_ltf_array.ltf_eval(transformed_inputs), decimals=10)
             )
 
 
 class TestSimulationMajorityLTFArray(unittest.TestCase):
+    """This class is used to test the SimulationMajorityLTFArray class."""
     def test_majority_voting(self):
+        """This method is used to test if majority vote works.
+        The first test checks for unequal PUF responses with a LTFArray without noise and a SimulationMajorityLTFArray
+        instance with noise. The second test checks if majority voting works and the instance with and without noise
+        generate equal resonses.
+        """
         weight_prng1 = RandomState(seed=0xBADA55)
         noise_prng = RandomState(seed=0xC0FFEE)
         crp_count = 16  # number of random inputs per test set
@@ -653,6 +689,13 @@ class TestSimulationMajorityLTFArray(unittest.TestCase):
         inputs = array(list(tools.random_inputs(n, crp_count, random_instance=RandomState(seed=0xDEADDA7A))))
 
         def get_functions_with_prefix(prefix, obj):
+            """
+            This function return all functions with a prefix.
+            :param prefix: string
+            :param obj: object
+                        Object to investigate
+            :return list of strings
+            """
             return [func for func in dir(obj) if func.startswith(prefix)]
 
         combiners = get_functions_with_prefix('combiner_', SimulationMajorityLTFArray)


### PR DESCRIPTION
This fixes most of the linter issues with the regression module, as per #67 

I left a couple of issues up to you:

	************* Module pypuf.learner.regression.logistic_regression
	W:  8, 0: Redefining built-in 'abs' (redefined-builtin)
	E:  8, 0: Unable to import 'numpy' (import-error)
	E:  9, 0: Unable to import 'numpy.random' (import-error)
	E: 10, 0: Unable to import 'numpy.linalg' (import-error)
	C: 65,16: Invalid variable name "l" (invalid-name)
	C:166, 8: Invalid argument name "l" (invalid-name)
	C:171, 8: Invalid argument name "l" (invalid-name)

For the first, I am not sure if we really want to `import numpy` altogether, but I also don't know any other option to fix this.

For the import errors, I believe it's a bug with the linter. (possibly wrong paths? I am running this inside a virtualenv.)

Finally, I believe for pypuf, one-letter variable names in a mathematical context should be allowed.

Please merge at will into your `feature_pep8_linter` branch or request changes. 

Cheers