### PR TITLE
Switch to pypuf helper

### DIFF
--- a/pypuf/simulation/arbiter_based/ltfarray.py
+++ b/pypuf/simulation/arbiter_based/ltfarray.py
@@ -1,8 +1,11 @@
+import time
 from numpy import sum, prod, shape, sign, dot, array, tile, transpose, concatenate, dstack, swapaxes, sqrt, amax,\
-    vectorize, tile
+    vectorize, tile, around, set_printoptions
 from numpy.random import RandomState
 from pypuf import tools
 from pypuf.simulation.base import Simulation
+from numpy.testing import assert_array_equal
+import pypuf_helper as ph
 
 
 class LTFArray(Simulation):
@@ -18,7 +21,7 @@ class LTFArray(Simulation):
         :param r: a list with a number of vectors of single LTF results
         :return: a list of full results, one for each
         """
-        return prod(r, 1)
+        return ph.combiner_xor(r)
 
     @staticmethod
     def combiner_ip_mod2(r):
@@ -43,10 +46,8 @@ class LTFArray(Simulation):
         Input transformation that does nothing.
         :return:
         """
-        return array([
-                tile(c, (k, 1))  # same unmodified challenge for all k LTFs
-                for c in cs
-            ])
+        # Old numpy version
+        return ph.transform_id(cs, k)
 
     @staticmethod
     def transform_atf(cs, k):
@@ -515,15 +516,7 @@ class LTFArray(Simulation):
         """
         :return: array
         """
-        return transpose(
-            array([
-                dot(
-                    inputs[:,l],
-                    self.weight_array[l]
-                )
-                for l in range(self.k)
-            ])
-        )
+        return ph.eval(inputs, self.weight_array)
 
 
 class NoisyLTFArray(LTFArray):

--- a/pypuf/simulation/arbiter_based/ltfarray.py
+++ b/pypuf/simulation/arbiter_based/ltfarray.py
@@ -46,7 +46,6 @@ class LTFArray(Simulation):
         Input transformation that does nothing.
         :return:
         """
-        # Old numpy version
         return ph.transform_id(cs, k)
 
     @staticmethod

--- a/pypuf/simulation/arbiter_based/ltfarray.py
+++ b/pypuf/simulation/arbiter_based/ltfarray.py
@@ -506,7 +506,7 @@ class LTFArray(Simulation):
         :return: list of responses
         """
         if self.bias:
-            inputs = tools.iter_append_last(inputs, 1)
+            inputs = tools.append_last(inputs, 1)
         return sign(self.val(inputs))
 
     def val(self, inputs):

--- a/pypuf/tools.py
+++ b/pypuf/tools.py
@@ -48,6 +48,17 @@ def iter_append_last(array_iterator, x):
     for array in array_iterator:
         yield append(array, x)
 
+def append_last(array_like, x):
+    """
+    Returns an array for a given array array_like and appends on the axis 1 the element x.
+    :param array_like: matrix with initial values
+    :param x: element to be appended
+    :return: initial array_like with appended element x
+    """
+    append_array = zeros((array_like.shape[0],1), dtype=int)
+    append_array += x
+    return append(array_like, append_array, axis=1)
+
 
 def approx_dist(a, b, num, random_instance=RandomState()):
     """

--- a/pypuf/tools.py
+++ b/pypuf/tools.py
@@ -55,7 +55,7 @@ def append_last(array_like, x):
     :param x: element to be appended
     :return: initial array_like with appended element x
     """
-    append_array = zeros((array_like.shape[0],1), dtype=int)
+    append_array = zeros((array_like.shape[0], 1), dtype=int)
     append_array += x
     return append(array_like, append_array, axis=1)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy
 scipy
 polymath
+pypuf_helper

--- a/test/test_simulation.py
+++ b/test/test_simulation.py
@@ -12,15 +12,15 @@ class TestCombiner(unittest.TestCase):
         assert_array_equal(
             LTFArray.combiner_xor(
                 [
-                    [ 1,  1, -3,  1],
-                    [-1, -1, -1,  1],
-                    [-2, -2,  2,  1]
+                    [ 1.,  1., -3.,  1.],
+                    [-1., -1., -1.,  1.],
+                    [-2., -2.,  2.,  1.]
                 ]
             ),
             [
-                -3,
-                -1,
-                8
+                -3.,
+                -1.,
+                8.
             ]
         )
 
@@ -523,13 +523,13 @@ class TestLTFArray(unittest.TestCase):
                 combiner=LTFArray.combiner_xor,
             )
 
-            fast_evaluation_result = around(ltf_array.ltf_eval(LTFArray.transform_id(inputs, k)), decimals=10)
+            fast_evaluation_result = around(ltf_array.ltf_eval(LTFArray.transform_id(inputs, k)), decimals=8)
             slow_evaluation_result = []
             for c in inputs:
                 slow_evaluation_result.append(
                     [ltf_eval_slow(c, ltf_array.weight_array[l]) for l in range(k)]
                 )
-            slow_evaluation_result = around(slow_evaluation_result, decimals=10)
+            slow_evaluation_result = around(slow_evaluation_result, decimals=8)
 
             self.assertTupleEqual(shape(slow_evaluation_result), (N, k))
             self.assertTupleEqual(shape(fast_evaluation_result), (N, k))

--- a/test/test_simulation.py
+++ b/test/test_simulation.py
@@ -481,7 +481,7 @@ class TestLTFArray(unittest.TestCase):
                 bias = False,
             )
             biased_eval = biased_ltf_array.eval(inputs)
-            inputs = tools.iter_append_last(inputs, 1)\
+            inputs = tools.append_last(inputs, 1)\
                 if biased_ltf_array.bias else inputs
             eval = ltf_array.eval(inputs)
 


### PR DESCRIPTION
`pypuf_helper` (https://github.com/taudor/pypuf_helper) is a small C extension that will help us to speed up the computation of time critical parts of `pypuf`.
Right now the functions `combiner_xor`, `transform_id`, and `ltf_eval` are supported by `pypuf_helper`.
As `pypuf_helper` operates on `numpy` arrays, the function `append_last` is added, that returns an `array` in comparison to the existing function `iter_append_last` that returns an iterator.