### PR TITLE
Rework Tests Logfile Deletion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
+test/logs/*
 
 # Translations
 *.mo

--- a/mv_num_of_votes.py
+++ b/mv_num_of_votes.py
@@ -24,10 +24,11 @@ s_ratio: float
          The noisiness factor which is used to scale sigma_noise. The value sigma_noise
          is the standard deviation of the noise distribution of the PUF instance simulation.
 N: int
-   values: range(10, 10001, 10)
    The number of challenges which are used to evaluate the PUF.
 restarts: int
           Number of restarts to the entire process
+[log_name]: string default 'my_num_of_votes'
+            Path to the main log file.
 """
 from sys import stderr, argv
 import argparse
@@ -53,8 +54,10 @@ def main(args):
     parser.add_argument("k_range", help="Number of step size between the number of Arbiter chains", type=int,
                         choices=range(1, 33))
     parser.add_argument("s_ratio", help="Ratio of standard deviation of the noise and weights", type=float)
-    parser.add_argument("N", help="Number of challenges to evaluate", type=int, choices=range(10, 10001, 10))
+    parser.add_argument("N", help="Number of challenges to evaluate", type=int)
     parser.add_argument("restarts", help="Number of restarts to the entire process", type=int)
+    parser.add_argument("--log_name", help="Path to the main log file.", type=str,
+                        default='my_num_of_votes')
     args = parser.parse_args(args)
 
     if args.k_max <= 0:
@@ -70,7 +73,7 @@ def main(args):
     experiments = []
     for i in range(args.restarts):
         for k in range(args.k_range, args.k_max + 1, args.k_range):
-            log_name = 'exp{0}'.format(k)
+            log_name = args.log_name+'{0}'.format(k)
             exp = ExperimentMajorityVoteFindVotes(
                 log_name=log_name,
                 n=n,
@@ -92,7 +95,7 @@ def main(args):
             )
             experiments.append(exp)
 
-    experimenter = Experimenter('mv', experiments)
+    experimenter = Experimenter(args.log_name, experiments)
     experimenter.run()
 
 if __name__ == '__main__':

--- a/test/test_experimenter.py
+++ b/test/test_experimenter.py
@@ -1,7 +1,7 @@
 """This module test the experimenter class which is used to distribute experiments over several cores."""
 import unittest
-import os
 import glob
+from test.utility import remove_test_logs, LOG_PATH
 from pypuf.simulation.arbiter_based.ltfarray import LTFArray, NoisyLTFArray
 from pypuf.experiments.experiment.base import Experiment
 from pypuf.experiments.experiment.logistic_regression import ExperimentLogisticRegression
@@ -15,35 +15,31 @@ class TestExperimenter(unittest.TestCase):
     """
     def setUp(self):
         # Remove all log files
-        paths = list(glob.glob('*.log'))
-        for path in paths:
-            os.remove(path)
+        remove_test_logs()
 
     def tearDown(self):
         # Remove all log files
-        paths = list(glob.glob('*.log'))
-        for path in paths:
-            os.remove(path)
+        remove_test_logs()
 
     def test_lr_experiments(self):
         """This method runs the experimenter for four logistic regression experiments."""
-        lr16_4_1 = ExperimentLogisticRegression('test_lr_experiments1', 8, 2, 2 ** 8, 0xbeef, 0xbeef,
+        lr16_4_1 = ExperimentLogisticRegression(LOG_PATH+'test_lr_experiments1', 8, 2, 2 ** 8, 0xbeef, 0xbeef,
                                                 LTFArray.transform_id,
                                                 LTFArray.combiner_xor)
-        lr16_4_2 = ExperimentLogisticRegression('test_lr_experiments2', 8, 2, 2 ** 8, 0xbeef, 0xbeef,
+        lr16_4_2 = ExperimentLogisticRegression(LOG_PATH+'test_lr_experiments2', 8, 2, 2 ** 8, 0xbeef, 0xbeef,
                                                 LTFArray.transform_id,
                                                 LTFArray.combiner_xor)
-        lr16_4_3 = ExperimentLogisticRegression('test_lr_experiments3', 8, 2, 2 ** 8, 0xbeef, 0xbeef,
+        lr16_4_3 = ExperimentLogisticRegression(LOG_PATH+'test_lr_experiments3', 8, 2, 2 ** 8, 0xbeef, 0xbeef,
                                                 LTFArray.transform_id,
                                                 LTFArray.combiner_xor)
-        lr16_4_4 = ExperimentLogisticRegression('test_lr_experiments4', 8, 2, 2 ** 8, 0xbeef, 0xbeef,
+        lr16_4_4 = ExperimentLogisticRegression(LOG_PATH+'test_lr_experiments4', 8, 2, 2 ** 8, 0xbeef, 0xbeef,
                                                 LTFArray.transform_id,
                                                 LTFArray.combiner_xor)
-        lr16_4_5 = ExperimentLogisticRegression('test_lr_experiments5', 8, 2, 2 ** 8, 0xbeef, 0xbeef,
+        lr16_4_5 = ExperimentLogisticRegression(LOG_PATH+'test_lr_experiments5', 8, 2, 2 ** 8, 0xbeef, 0xbeef,
                                                 LTFArray.transform_id,
                                                 LTFArray.combiner_xor)
         experiments = [lr16_4_1, lr16_4_2, lr16_4_3, lr16_4_4, lr16_4_5]
-        experimenter = Experimenter('log', experiments)
+        experimenter = Experimenter(LOG_PATH+'test_lr_experiments', experiments)
         experimenter.run()
 
     def test_mv_experiments(self):
@@ -51,7 +47,7 @@ class TestExperimenter(unittest.TestCase):
         experiments = []
         for i in range(5):
             n = 8
-            logger_name = 'test_mv_exp{0}'.format(i)
+            logger_name = LOG_PATH+'test_mv_exp{0}'.format(i)
             experiment = ExperimentMajorityVoteFindVotes(
                 log_name=logger_name,
                 n=n,
@@ -72,7 +68,7 @@ class TestExperimenter(unittest.TestCase):
                 bias=None
             )
             experiments.append(experiment)
-        experimenter = Experimenter('test_mv_experimenter', experiments)
+        experimenter = Experimenter(LOG_PATH+'test_mv_experiments', experiments)
         experimenter.run()
 
     def test_multiprocessing_logs(self):
@@ -82,14 +78,14 @@ class TestExperimenter(unittest.TestCase):
         experiments = []
         n = 28
         for i in range(n):
-            log_name = 'test_multiprocessing_logs{0}'.format(i)
+            log_name = LOG_PATH+'test_multiprocessing_logs{0}'.format(i)
             lr16_4_1 = ExperimentLogisticRegression(log_name, 8, 2, 2 ** 8, 0xbeef, 0xbeef,
                                                     LTFArray.transform_id,
                                                     LTFArray.combiner_xor)
             experiments.append(lr16_4_1)
 
         for i in range(n):
-            log_name = 'test_multiprocessing_logs{0}'.format(i)
+            log_name = LOG_PATH+'test_multiprocessing_logs{0}'.format(i)
             experiment = ExperimentMajorityVoteFindVotes(
                 log_name=log_name,
                 n=8,
@@ -111,7 +107,8 @@ class TestExperimenter(unittest.TestCase):
             )
             experiments.append(experiment)
 
-        experimenter = Experimenter('test_multiprocessing_logs', experiments)
+        experimenter_log_name = LOG_PATH+'test_multiprocessing_logs'
+        experimenter = Experimenter(experimenter_log_name, experiments)
         experimenter.run()
 
         def line_count(file_object):
@@ -124,7 +121,7 @@ class TestExperimenter(unittest.TestCase):
                 count = count + 1
             return count
 
-        paths = list(glob.glob('*.log'))
+        paths = list(glob.glob(LOG_PATH+'*.log'))
         # Check if the number of lines is greater than zero
         for log_path in paths:
             exp_log_file = open(log_path, 'r')
@@ -132,7 +129,7 @@ class TestExperimenter(unittest.TestCase):
             exp_log_file.close()
 
         # Check if the number of results is correct
-        log_file = open('test_multiprocessing_logs.log', 'r')
+        log_file = open(experimenter_log_name+'.log', 'r')
         self.assertEqual(line_count(log_file), n*2, 'Unexpected number of results')
         log_file.close()
 
@@ -154,8 +151,8 @@ class TestExperimenter(unittest.TestCase):
         experiments = []
         n = 1024
         for i in range(n):
-            log_name = 'fail{0}'.format(i)
+            log_name = LOG_PATH+'fail{0}'.format(i)
             experiments.append(ExperimentDummy(log_name))
 
-        experimenter = Experimenter('fail', experiments)
+        experimenter = Experimenter(LOG_PATH+'test_file_handle', experiments)
         experimenter.run()

--- a/test/test_mv_num_of_votes.py
+++ b/test/test_mv_num_of_votes.py
@@ -3,27 +3,37 @@ This module is used to test the command line tool which searches the number of v
 SimulationMajorityLTFArrays in order to satisfy a overall desired stability.
 """
 import unittest
+from test.utility import remove_test_logs, LOG_PATH
 import mv_num_of_votes
 
 
 class TestMvNumOfVotes(unittest.TestCase):
     """This class is used to test the mv_num_of_votes commandline tool"""
+    def setUp(self):
+        # Remove all log files
+        remove_test_logs()
+
+    def tearDown(self):
+        # Remove all log files
+        remove_test_logs()
 
     def test_8_1_puf(self):
         """
         This method checks the output log of mv_num_of_votes for a stability greater equal the
         overall_desired_stability.
         """
+        log_name = LOG_PATH+"test_8_1_puf"
         overall_desired_stability = 0.8
-        mv_num_of_votes.main(["0.95", str(overall_desired_stability), "8", "1", "1", "0.33", "250", "1"])
+        mv_num_of_votes.main(["0.95", str(overall_desired_stability), "8", "1", "1", "0.33", "250", "1", "--log_name",
+                              log_name])
 
         # Check if the number of results is correct
-        with open('exp1.0xc0deba5e_0_8_1_250_transform_id_combiner_xor.log', 'r') as log_file:
-            line = log_file.readline()
-            while line != '':
-                stability = float(line.split('\t')[0])
-                if stability >= overall_desired_stability:
-                    break
+        log_file = open(log_name + '.log', 'r')
+        line = log_file.readline()
 
-        # if the line is '' then no stability where found which satisfy overall_desired_stability
-        self.assertNotEqual(line, '', 'stability where found which satisfy overall_desired_stability')
+        # If the line is '' then no stability where found which satisfy overall_desired_stability
+        self.assertNotEqual(line, '', 'no stability where found which satisfy overall_desired_stability')
+        # Get the stability entry
+        stability = float(line.split('\t')[6])
+        # Check the stability
+        self.assertGreaterEqual(stability, overall_desired_stability)

--- a/test/test_sim_learn.py
+++ b/test/test_sim_learn.py
@@ -1,8 +1,6 @@
 """This module tests the sim_learn command line script."""
 import unittest
-import os
-import glob
-from test.utility import mute
+from test.utility import remove_test_logs, LOG_PATH, mute
 import sim_learn
 
 
@@ -12,91 +10,98 @@ class TestSimLearn(unittest.TestCase):
     """
     def setUp(self):
         # Remove all log files
-        paths = list(glob.glob('*.log'))
-        for path in paths:
-            os.remove(path)
+        remove_test_logs()
 
     def tearDown(self):
         # Remove all log files
-        paths = list(glob.glob('*.log'))
-        for path in paths:
-            os.remove(path)
+        remove_test_logs()
 
     @mute
     def test_id(self):
         """This tests the id transformation and xor combiner."""
-        sim_learn.main(["sim_learn", "8", "2", "id", "xor", "20", "1", "2", "1234", "1234"])
+        sim_learn.main(["sim_learn", "8", "2", "id", "xor", "20", "1", "2", "1234", "1234", LOG_PATH + "test_id"])
 
     @mute
     def test_atf(self):
         """This tests the atf transformation and xor combiner."""
-        sim_learn.main(["sim_learn", "8", "2", "atf", "xor", "20", "1", "2", "1234", "1234"])
+        sim_learn.main(["sim_learn", "8", "2", "atf", "xor", "20", "1", "2", "1234", "1234", LOG_PATH + "test_atf"])
 
     @mute
     def test_mm(self):
         """This tests the mm transformation and xor combiner."""
-        sim_learn.main(["sim_learn", "8", "2", "mm", "xor", "20", "1", "2", "1234", "1234"])
+        sim_learn.main(["sim_learn", "8", "2", "mm", "xor", "20", "1", "2", "1234", "1234", LOG_PATH + "test_mm"])
 
     @mute
     def test_lightweight_secure(self):
         """This tests the lightweight secure transformation and xor combiner."""
-        sim_learn.main(["sim_learn", "8", "2", "lightweight_secure", "xor", "20", "1", "2", "1234", "1234"])
+        sim_learn.main(["sim_learn", "8", "2", "lightweight_secure", "xor", "20", "1", "2", "1234", "1234",
+                        LOG_PATH + "test_lightweight_secure"])
 
     @mute
     def test_lightweight_secure_original(self):
         """This tests the lightweight secure original transformation and xor combiner."""
-        sim_learn.main(["sim_learn", "8", "2", "lightweight_secure_original", "xor", "20", "1", "2", "1234", "1234"])
+        sim_learn.main(["sim_learn", "8", "2", "lightweight_secure_original", "xor", "20", "1", "2", "1234", "1234",
+                        LOG_PATH+"test_lightweight_secure_original"])
 
     @mute
     def test_1_n_bent(self):
         """This tests the one to n bent transformation and xor combiner."""
-        sim_learn.main(["sim_learn", "8", "2", "1_n_bent", "xor", "20", "1", "2", "1234", "1234"])
+        sim_learn.main(["sim_learn", "8", "2", "1_n_bent", "xor", "20", "1", "2", "1234", "1234",
+                        LOG_PATH + "test_1_n_bent"])
 
     @mute
     def test_1_1_bent(self):
         """This tests the one to one bent transformation and xor combiner."""
-        sim_learn.main(["sim_learn", "8", "2", "1_1_bent", "xor", "20", "1", "2", "1234", "1234"])
+        sim_learn.main(["sim_learn", "8", "2", "1_1_bent", "xor", "20", "1", "2", "1234", "1234",
+                        LOG_PATH + "test_1_1_bent"])
 
     @mute
     def test_ip_mod2_id(self):
         """This tests the identity transformation and inner product mod 2 combiner."""
-        sim_learn.main(["sim_learn", "8", "2", "id", "ip_mod2", "20", "1", "2", "1234", "1234"])
+        sim_learn.main(["sim_learn", "8", "2", "id", "ip_mod2", "20", "1", "2", "1234", "1234",
+                        LOG_PATH + "test_ip_mod2_id"])
 
     @mute
     def test_ip_mod2_atf(self):
         """This tests the atf transformation and inner product mod 2 combiner."""
-        sim_learn.main(["sim_learn", "8", "2", "atf", "ip_mod2", "20", "1", "2", "1234", "1234"])
+        sim_learn.main(["sim_learn", "8", "2", "atf", "ip_mod2", "20", "1", "2", "1234", "1234",
+                        LOG_PATH + "test_ip_mod2_atf"])
 
     @mute
     def test_ip_mod2_mm(self):
         """This tests the mm transformation and inner product mod 2 combiner."""
-        sim_learn.main(["sim_learn", "8", "2", "mm", "ip_mod2", "20", "1", "2", "1234", "1234"])
+        sim_learn.main(["sim_learn", "8", "2", "mm", "ip_mod2", "20", "1", "2", "1234", "1234",
+                        LOG_PATH + "test_ip_mod2_mm"])
 
     @mute
     def test_ip_mod2_lightweight_secure(self):
         """This tests the lightweight secure transformation and inner product mod 2 combiner."""
-        sim_learn.main(["sim_learn", "8", "2", "lightweight_secure", "ip_mod2", "20", "1", "2", "1234", "1234"])
+        sim_learn.main(["sim_learn", "8", "2", "lightweight_secure", "ip_mod2", "20", "1", "2", "1234", "1234",
+                        LOG_PATH + "test_ip_mod2_lightweight_secure"])
 
     @mute
     def test_ip_mod2_1_n_bent(self):
         """This tests the one to n bent transformation and inner product mod 2 combiner."""
-        sim_learn.main(["sim_learn", "8", "2", "1_n_bent", "ip_mod2", "20", "1", "2", "1234", "1234"])
+        sim_learn.main(["sim_learn", "8", "2", "1_n_bent", "ip_mod2", "20", "1", "2", "1234", "1234",
+                        LOG_PATH + "test_ip_mod2_1_n_bent"])
 
     @mute
     def test_ip_mod2_1_1_bent(self):
         """This tests the one to one bent transformation and inner product mod 2 combiner."""
-        sim_learn.main(["sim_learn", "8", "2", "1_1_bent", "ip_mod2", "20", "1", "2", "1234", "1234"])
+        sim_learn.main(["sim_learn", "8", "2", "1_1_bent", "ip_mod2", "20", "1", "2", "1234", "1234",
+                        LOG_PATH+"test_ip_mod2_1_1_bent"])
 
     @mute
     def test_permutation_atf(self):
         """This tests the atf permutation transformation and xor combiner."""
-        sim_learn.main(["sim_learn", "8", "2", "permutation_atf", "xor", "10", "1", "2", "1234", "1234"])
+        sim_learn.main(["sim_learn", "8", "2", "permutation_atf", "xor", "10", "1", "2", "1234", "1234",
+                        LOG_PATH + "test_permutation_atf"])
 
     @mute
     def test_log_name(self):
         """This tests for the expected number of lines in the main log file."""
         instance_count = 2
-        log_name = 'test_log'
+        log_name = LOG_PATH + 'test_log_name'
         sim_learn.main(["sim_learn", "8", "2", "id", "xor", "10", "1", str(instance_count), "1234", "1234", log_name])
 
         def line_count(file_object):
@@ -115,14 +120,14 @@ class TestSimLearn(unittest.TestCase):
         log_file.close()
 
     @mute
-    def test_number_of_reults(self):
+    def test_number_of_results(self):
         """
         This test checks the number of results to match a previous calculated value.
         """
         instance_count = 7
         restarts = 13
         expected_number_of_result = instance_count * restarts
-        log_name = 'test_log'
+        log_name = LOG_PATH + 'test_number_of_results'
         sim_learn.main(
             ["sim_learn", "8", "2", "id", "xor", "10", str(restarts), str(instance_count), "1234", "1234", log_name]
         )

--- a/test/utility.py
+++ b/test/utility.py
@@ -9,7 +9,7 @@ from io import StringIO
 from functools import wraps
 from pypuf.experiments.experimenter import log_listener, setup_logger
 
-LOG_PATH = 'test/'
+LOG_PATH = 'test/logs/'
 LOG_NAME = 'test_log'
 
 


### PR DESCRIPTION
The PR changes the log file creation for tests from pypuf/. to pypuf/test.
This should prevent unexpected deletion of real results.

Serves #74 