### PR TITLE
Rework test log output

### DIFF
--- a/sim_learn.py
+++ b/sim_learn.py
@@ -3,7 +3,7 @@ This module is a command line tool which provides an interface for experiments w
 PUF LTFarray simulation with the logistic regression learning algorithm. If you want to use this tool you will have to
 define nine parameters which define the experiment.
 """
-from sys import argv, stderr
+import sys
 from pypuf.simulation.arbiter_based.ltfarray import LTFArray
 from pypuf.experiments.experiment.logistic_regression import ExperimentLogisticRegression
 from pypuf.experiments.experimenter import Experimenter
@@ -15,54 +15,54 @@ def main(args):
     attempts on the PUF instances.
     """
     if len(args) < 10 or len(args) > 11:
-        stderr.write('LTF Array Simulator and Logistic Regression Learner\n')
-        stderr.write('Usage:\n')
-        stderr.write('sim_learn.py n k transformation combiner N restarts seed_instance seed_model [log_name]\n')
-        stderr.write('               n: number of bits per Arbiter chain\n')
-        stderr.write('               k: number of Arbiter chains\n')
-        stderr.write('  transformation: used to transform input before it is used in LTFs\n')
-        stderr.write('                  currently available:\n')
-        stderr.write('                  - id  -- does nothing at all\n')
-        stderr.write('                  - atf -- convert according to "natural" Arbiter chain\n')
-        stderr.write('                           implementation\n')
-        stderr.write('                  - mm  -- designed to achieve maximum PTF expansion length\n')
-        stderr.write('                           only implemented for k=2 and even n\n')
-        stderr.write('                  - lightweight_secure -- design by Majzoobi et al. 2008\n')
-        stderr.write('                                          only implemented for even n\n')
-        stderr.write('                  - shift_lightweight_secure -- design like Majzoobi\n')
-        stderr.write('                                                et al. 2008, but with the shift\n')
-        stderr.write('                                                operation executed first\n')
-        stderr.write('                                                only implemented for even n\n')
-        stderr.write('                  - soelter_lightweight_secure -- design like Majzoobi\n')
-        stderr.write('                                                  et al. 2008, but one bit different\n')
-        stderr.write('                                                  only implemented for even n\n')
-        stderr.write('                  - 1_n_bent -- one LTF gets "bent" input, the others id\n')
-        stderr.write('                  - 1_1_bent -- one bit gets "bent" input, the others id,\n')
-        stderr.write('                                this is proven to have maximum PTF\n')
-        stderr.write('                                length for the model\n')
-        stderr.write('                  - polynomial -- challenges are interpreted as polynomials\n')
-        stderr.write('                                  from GF(2^64). From the initial challenge c,\n')
-        stderr.write('                                  the i-th Arbiter chain gets the coefficients \n')
-        stderr.write('                                  of the polynomial c^(i+1) as challenge.\n')
-        stderr.write('                                  For now only challenges with length n=64 are accepted.\n')
-        stderr.write(
+        sys.stderr.write('LTF Array Simulator and Logistic Regression Learner\n')
+        sys.stderr.write('Usage:\n')
+        sys.stderr.write('sim_learn.py n k transformation combiner N restarts seed_instance seed_model [log_name]\n')
+        sys.stderr.write('               n: number of bits per Arbiter chain\n')
+        sys.stderr.write('               k: number of Arbiter chains\n')
+        sys.stderr.write('  transformation: used to transform input before it is used in LTFs\n')
+        sys.stderr.write('                  currently available:\n')
+        sys.stderr.write('                  - id  -- does nothing at all\n')
+        sys.stderr.write('                  - atf -- convert according to "natural" Arbiter chain\n')
+        sys.stderr.write('                           implementation\n')
+        sys.stderr.write('                  - mm  -- designed to achieve maximum PTF expansion length\n')
+        sys.stderr.write('                           only implemented for k=2 and even n\n')
+        sys.stderr.write('                  - lightweight_secure -- design by Majzoobi et al. 2008\n')
+        sys.stderr.write('                                          only implemented for even n\n')
+        sys.stderr.write('                  - shift_lightweight_secure -- design like Majzoobi\n')
+        sys.stderr.write('                                                et al. 2008, but with the shift\n')
+        sys.stderr.write('                                                operation executed first\n')
+        sys.stderr.write('                                                only implemented for even n\n')
+        sys.stderr.write('                  - soelter_lightweight_secure -- design like Majzoobi\n')
+        sys.stderr.write('                                                  et al. 2008, but one bit different\n')
+        sys.stderr.write('                                                  only implemented for even n\n')
+        sys.stderr.write('                  - 1_n_bent -- one LTF gets "bent" input, the others id\n')
+        sys.stderr.write('                  - 1_1_bent -- one bit gets "bent" input, the others id,\n')
+        sys.stderr.write('                                this is proven to have maximum PTF\n')
+        sys.stderr.write('                                length for the model\n')
+        sys.stderr.write('                  - polynomial -- challenges are interpreted as polynomials\n')
+        sys.stderr.write('                                  from GF(2^64). From the initial challenge c,\n')
+        sys.stderr.write('                                  the i-th Arbiter chain gets the coefficients \n')
+        sys.stderr.write('                                  of the polynomial c^(i+1) as challenge.\n')
+        sys.stderr.write('                                  For now only challenges with length n=64 are accepted.\n')
+        sys.stderr.write(
             '                  - permutation_atf -- for each Arbiter chain first a pseudorandom permutation \n')
-        stderr.write('                                       is applied and thereafter the ATF transform.\n')
-        stderr.write('                  - random -- Each Arbiter chain gets a random challenge derived from the\n')
-        stderr.write('                              original challenge using a PRNG.\n')
-        stderr.write('        combiner: used to combine the output bits to a single bit\n')
-        stderr.write('                  currently available:\n')
-        stderr.write('                  - xor     -- output the parity of all output bits\n')
-        stderr.write('                  - ip_mod2 -- output the inner product mod 2 of all output\n')
-        stderr.write('                               bits (even n only)\n')
-        stderr.write('               N: number of challenge response pairs in the training set\n')
-        stderr.write('        restarts: number of repeated initializations the learner\n')
-        stderr.write('       instances: number of repeated initializations the instance\n')
-        stderr.write('                  The number total learning attempts is restarts*instances.\n')
-        stderr.write('   seed_instance: random seed used for LTF array instance\n')
-        stderr.write('      seed_model: random seed used for the model in first learning attempt\n')
-        stderr.write('      [log_name]: path to the logfile which contains results from all instances. The tool '
-                     'will add a ".log" to log_name. The default path is ./sim_learn.log\n')
+        sys.stderr.write('                                       is applied and thereafter the ATF transform.\n')
+        sys.stderr.write('                  - random -- Each Arbiter chain gets a random challenge derived from the\n')
+        sys.stderr.write('                              original challenge using a PRNG.\n')
+        sys.stderr.write('        combiner: used to combine the output bits to a single bit\n')
+        sys.stderr.write('                  currently available:\n')
+        sys.stderr.write('                  - xor     -- output the parity of all output bits\n')
+        sys.stderr.write('                  - ip_mod2 -- output the inner product mod 2 of all output\n')
+        sys.stderr.write('                               bits (even n only)\n')
+        sys.stderr.write('               N: number of challenge response pairs in the training set\n')
+        sys.stderr.write('        restarts: number of repeated initializations the learner\n')
+        sys.stderr.write('       instances: number of repeated initializations the instance\n')
+        sys.stderr.write('                  The number total learning attempts is restarts*instances.\n')
+        sys.stderr.write('   seed_instance: random seed used for LTF array instance\n')
+        sys.stderr.write('      seed_model: random seed used for the model in first learning attempt\n')
+        sys.stderr.write('      [log_name]: path to the logfile which contains results from all instances. The tool '
+                         'will add a ".log" to log_name. The default path is ./sim_learn.log\n')
         quit(1)
 
     n = int(args[1])
@@ -83,26 +83,26 @@ def main(args):
     try:
         transformation = getattr(LTFArray, 'transform_%s' % transformation_name)
     except AttributeError:
-        stderr.write('Transformation %s unknown or currently not implemented\n' % transformation_name)
+        sys.stderr.write('Transformation %s unknown or currently not implemented\n' % transformation_name)
         quit()
 
     try:
         combiner = getattr(LTFArray, 'combiner_%s' % combiner_name)
     except AttributeError:
-        stderr.write('Combiner %s unknown or currently not implemented\n' % combiner_name)
+        sys.stderr.write('Combiner %s unknown or currently not implemented\n' % combiner_name)
         quit()
 
     log_name = 'sim_learn'
     if len(args) == 11:
         log_name = args[10]
 
-    stderr.write('Learning %s-bit %s XOR Arbiter PUF with %s CRPs and %s restarts.\n\n' % (n, k, N, restarts))
-    stderr.write('Using\n')
-    stderr.write('  transformation:       %s\n' % transformation)
-    stderr.write('  combiner:             %s\n' % combiner)
-    stderr.write('  instance random seed: 0x%x\n' % seed_instance)
-    stderr.write('  model random seed:    0x%x\n' % seed_model)
-    stderr.write('\n')
+    sys.stderr.write('Learning %s-bit %s XOR Arbiter PUF with %s CRPs and %s restarts.\n\n' % (n, k, N, restarts))
+    sys.stderr.write('Using\n')
+    sys.stderr.write('  transformation:       %s\n' % transformation)
+    sys.stderr.write('  combiner:             %s\n' % combiner)
+    sys.stderr.write('  instance random seed: 0x%x\n' % seed_instance)
+    sys.stderr.write('  model random seed:    0x%x\n' % seed_model)
+    sys.stderr.write('\n')
 
     # create different experiment instances
     experiments = []
@@ -132,17 +132,17 @@ def main(args):
         'model_values\n'
     )
     # print the result headline
-    stderr.write(headline)
+    sys.stderr.write(headline)
 
     log_file = open(log_name + '.log', 'r')
 
     # print the results
     result = log_file.readline()
     while result != '':
-        stderr.write(str_format.format(*result.split('\t')))
+        sys.stderr.write(str_format.format(*result.split('\t')))
         result = log_file.readline()
 
     log_file.close()
 
 if __name__ == '__main__':
-    main(argv)
+    main(sys.argv)

--- a/test/test_example.py
+++ b/test/test_example.py
@@ -2,6 +2,7 @@
 This module ensures that the example code is running with the current version of the framework.
 """
 import unittest
+from test.utility import mute
 import example
 
 
@@ -9,6 +10,7 @@ class TestExample(unittest.TestCase):
     """
     This class is used to execute the code examples.
     """
+    @mute
     def test_default(self):
         """
         This method just runs the example code in order to test for runtime errors.

--- a/test/test_mv_num_of_votes.py
+++ b/test/test_mv_num_of_votes.py
@@ -18,12 +18,12 @@ class TestMvNumOfVotes(unittest.TestCase):
         mv_num_of_votes.main(["0.95", str(overall_desired_stability), "8", "1", "1", "0.33", "250", "1"])
 
         # Check if the number of results is correct
-        log_file = open('exp1.0xc0deba5e_0_8_1_250_transform_id_combiner_xor.log', 'r')
-        line = log_file.readline()
-        while line != '':
-            stability = float(line.split('\t')[0])
-            if stability >= overall_desired_stability:
-                break
+        with open('exp1.0xc0deba5e_0_8_1_250_transform_id_combiner_xor.log', 'r') as log_file:
+            line = log_file.readline()
+            while line != '':
+                stability = float(line.split('\t')[0])
+                if stability >= overall_desired_stability:
+                    break
 
         # if the line is '' then no stability where found which satisfy overall_desired_stability
         self.assertNotEqual(line, '', 'stability where found which satisfy overall_desired_stability')

--- a/test/test_sim_learn.py
+++ b/test/test_sim_learn.py
@@ -2,6 +2,7 @@
 import unittest
 import os
 import glob
+from test.utility import mute
 import sim_learn
 
 
@@ -21,62 +22,77 @@ class TestSimLearn(unittest.TestCase):
         for path in paths:
             os.remove(path)
 
+    @mute
     def test_id(self):
         """This tests the id transformation and xor combiner."""
         sim_learn.main(["sim_learn", "8", "2", "id", "xor", "20", "1", "2", "1234", "1234"])
 
+    @mute
     def test_atf(self):
         """This tests the atf transformation and xor combiner."""
         sim_learn.main(["sim_learn", "8", "2", "atf", "xor", "20", "1", "2", "1234", "1234"])
 
+    @mute
     def test_mm(self):
         """This tests the mm transformation and xor combiner."""
         sim_learn.main(["sim_learn", "8", "2", "mm", "xor", "20", "1", "2", "1234", "1234"])
 
+    @mute
     def test_lightweight_secure(self):
         """This tests the lightweight secure transformation and xor combiner."""
         sim_learn.main(["sim_learn", "8", "2", "lightweight_secure", "xor", "20", "1", "2", "1234", "1234"])
 
+    @mute
     def test_lightweight_secure_original(self):
         """This tests the lightweight secure original transformation and xor combiner."""
         sim_learn.main(["sim_learn", "8", "2", "lightweight_secure_original", "xor", "20", "1", "2", "1234", "1234"])
 
+    @mute
     def test_1_n_bent(self):
         """This tests the one to n bent transformation and xor combiner."""
         sim_learn.main(["sim_learn", "8", "2", "1_n_bent", "xor", "20", "1", "2", "1234", "1234"])
 
+    @mute
     def test_1_1_bent(self):
         """This tests the one to one bent transformation and xor combiner."""
         sim_learn.main(["sim_learn", "8", "2", "1_1_bent", "xor", "20", "1", "2", "1234", "1234"])
 
+    @mute
     def test_ip_mod2_id(self):
         """This tests the identity transformation and inner product mod 2 combiner."""
         sim_learn.main(["sim_learn", "8", "2", "id", "ip_mod2", "20", "1", "2", "1234", "1234"])
 
+    @mute
     def test_ip_mod2_atf(self):
         """This tests the atf transformation and inner product mod 2 combiner."""
         sim_learn.main(["sim_learn", "8", "2", "atf", "ip_mod2", "20", "1", "2", "1234", "1234"])
 
+    @mute
     def test_ip_mod2_mm(self):
         """This tests the mm transformation and inner product mod 2 combiner."""
         sim_learn.main(["sim_learn", "8", "2", "mm", "ip_mod2", "20", "1", "2", "1234", "1234"])
 
+    @mute
     def test_ip_mod2_lightweight_secure(self):
         """This tests the lightweight secure transformation and inner product mod 2 combiner."""
         sim_learn.main(["sim_learn", "8", "2", "lightweight_secure", "ip_mod2", "20", "1", "2", "1234", "1234"])
 
+    @mute
     def test_ip_mod2_1_n_bent(self):
         """This tests the one to n bent transformation and inner product mod 2 combiner."""
         sim_learn.main(["sim_learn", "8", "2", "1_n_bent", "ip_mod2", "20", "1", "2", "1234", "1234"])
 
+    @mute
     def test_ip_mod2_1_1_bent(self):
         """This tests the one to one bent transformation and inner product mod 2 combiner."""
         sim_learn.main(["sim_learn", "8", "2", "1_1_bent", "ip_mod2", "20", "1", "2", "1234", "1234"])
 
+    @mute
     def test_permutation_atf(self):
         """This tests the atf permutation transformation and xor combiner."""
         sim_learn.main(["sim_learn", "8", "2", "permutation_atf", "xor", "10", "1", "2", "1234", "1234"])
 
+    @mute
     def test_log_name(self):
         """This tests for the expected number of lines in the main log file."""
         instance_count = 2
@@ -98,6 +114,7 @@ class TestSimLearn(unittest.TestCase):
         self.assertEqual(line_count(log_file), instance_count, 'Unexpected number of results')
         log_file.close()
 
+    @mute
     def test_number_of_reults(self):
         """
         This test checks the number of results to match a previous calculated value.

--- a/test/utility.py
+++ b/test/utility.py
@@ -4,6 +4,8 @@ This module provides some utility functions in oder to minimize duplicate code i
 import os
 import glob
 import multiprocessing
+import sys
+from io import StringIO
 from functools import wraps
 from pypuf.experiments.experimenter import log_listener, setup_logger
 
@@ -98,3 +100,72 @@ def get_functions_with_prefix(prefix, obj):
     :return list of function objects
     """
     return [getattr(obj, func) for func in dir(obj) if func.startswith(prefix)]
+
+
+class _RedirectStream:
+    """
+    Context manager for temporarily redirecting a stream to another file.
+    Copied from py35 contextlib because _RedirectStream is not available in py34 contextlib.
+    """
+    _stream = None
+
+    def __init__(self, new_target):
+        self._new_target = new_target
+        # We use a list of old targets to make this CM re-entrant
+        self._old_targets = []
+
+    def __enter__(self):
+        self._old_targets.append(getattr(sys, self._stream))
+        setattr(sys, self._stream, self._new_target)
+        return self._new_target
+
+    def __exit__(self, exctype, excinst, exctb):
+        setattr(sys, self._stream, self._old_targets.pop())
+
+
+class RedirectStdout(_RedirectStream):
+    """
+    Context manager for temporarily redirecting stdout to another file.
+    Copied from py35 contextlib because RedirectStdout is not available in py34 contextlib.
+    """
+
+    _stream = "stdout"
+
+
+class RedirectStderr(_RedirectStream):
+    """
+    Context manager for temporarily redirecting stderr to another file.
+    Copied from py35 contextlib because RedirectStderr is not available in py34 contextlib.
+    """
+
+    _stream = "stderr"
+
+
+def mute(function):
+    """
+    This function provides an function decorator which redirects the stderr and stdout stream to an stream object
+    in order to prevent console output.
+    """
+    def _mute(*args, **kwargs):
+        """
+        This method absorbs stderr and stdout streams.
+        :param args: extra positional generic arguments
+        :param kwargs: extra keyword arguments generic argument
+        :return: return value of `function`
+        """
+        output_sink = StringIO()
+        try:
+            from contextlib import redirect_stdout, redirect_stderr
+            redirect_out = redirect_stdout(output_sink)
+            redirect_err = redirect_stderr(output_sink)
+        except ImportError:
+            redirect_out = RedirectStdout(output_sink)
+            redirect_err = RedirectStderr(output_sink)
+        try:
+            # with redirect_stdout(output_sink):
+            with redirect_err, redirect_out:
+                result = function(*args, **kwargs)
+        except Exception as exception:
+            raise exception
+        return result
+    return wraps(function)(_mute)


### PR DESCRIPTION
This PR introduces a function wrapper named `mute` which can redirect the `sys.stderr` and `sys.stdout` of a function to an unused file object. For this purpose, I had to change the import of `stderr` of the `sys` module from  `from sys import stderr` to `import sys`. The import statements differ also semantically see https://docs.python.org/3/tutorial/modules.html#importing-from-a-package for details. Exceptions will still be printed. I also fixed a bug where a log file was not closed.