### PR TITLE
rework tools.py challenge type to int8

### DIFF
--- a/pypuf/experiments/experiment/majority_vote.py
+++ b/pypuf/experiments/experiment/majority_vote.py
@@ -187,7 +187,7 @@ class ExperimentMajorityVoteFindVotes(Experiment):
                                Pseudo-random number generator which is used to generate challenges.
         """
         challenges = tools.random_inputs(self.n, self.N, random_instance=challenge_prng)
-        eval_array = np.zeros(len(challenges))
+        eval_array = np.zeros(len(challenges), dtype=tools.RESULT_TYPE)
 
         # Evaluation of the PUF in order to measure the stability
         for i in range(self.iterations):

--- a/pypuf/experiments/experiment/majority_vote.py
+++ b/pypuf/experiments/experiment/majority_vote.py
@@ -186,7 +186,7 @@ class ExperimentMajorityVoteFindVotes(Experiment):
         :param challenge_prng: RandomState
                                Pseudo-random number generator which is used to generate challenges.
         """
-        challenges = np.array(list(tools.random_inputs(self.n, self.N, random_instance=challenge_prng)))
+        challenges = tools.random_inputs(self.n, self.N, random_instance=challenge_prng)
         eval_array = np.zeros(len(challenges))
 
         # Evaluation of the PUF in order to measure the stability

--- a/pypuf/learner/pac/low_degree.py
+++ b/pypuf/learner/pac/low_degree.py
@@ -102,4 +102,4 @@ class LowDegreeAlgorithm:
         :return iterator of arrays of length n
         """
         for indices in combinations(range(self.n), degree):
-            yield np.array([1 if i in indices else 0 for i in range(self.n)])
+            yield np.array([1 if i in indices else 0 for i in range(self.n)], dtype=tools.RESULT_TYPE)

--- a/pypuf/simulation/arbiter_based/ltfarray.py
+++ b/pypuf/simulation/arbiter_based/ltfarray.py
@@ -391,8 +391,7 @@ class LTFArray(Simulation):
         ])
 
         # Transform challenges back to -1,1 notation.
-        vtransform_to_11 = vectorize(tools.transform_challenge_01_to_11)
-        result = array([vtransform_to_11(c) for c in challenges])
+        result = array([tools.transform_challenge_01_to_11(c) for c in challenges])
 
         assert result.shape == (N, k, n), 'The resulting challenges have not the desired shape.'
         return result

--- a/pypuf/simulation/arbiter_based/ltfarray.py
+++ b/pypuf/simulation/arbiter_based/ltfarray.py
@@ -3,8 +3,7 @@ This module provides several different implementations of arbiter PUF simulation
 model is the core of each simulation class.
 """
 from numpy import sum as np_sum
-from numpy import prod, shape, sign, array, transpose, concatenate, dstack, swapaxes, sqrt, amax,\
-    vectorize, tile, append
+from numpy import prod, shape, sign, array, transpose, concatenate, dstack, swapaxes, sqrt, amax, tile, append
 from numpy.random import RandomState
 from pypuf import tools
 from pypuf.simulation.base import Simulation
@@ -51,49 +50,55 @@ class LTFArray(Simulation):
     def transform_id(challenges, k):
         """
         Input transformation that does nothing.
-        :param challenges: array of int shape(N,n)
+        :param challenges: array of int8 shape(N,n)
                            Array of challenges which should be evaluated by the simulation.
         :param k: int
                   Number of LTFArray PUFs
-        :return:  array of int shape(N,k,n)
+        :return:  array of int8 shape(N,k,n)
                   Array of transformed challenges.
         """
-        return ph.transform_id(challenges, k)
+        tools.assert_result_type(challenges)
+        res = ph.transform_id(challenges, k)
+        tools.assert_result_type(res)
+        return res
 
     @classmethod
     def transform_atf(cls, challenges, k):
         """
         Input transformation that simulates an Arbiter PUF
-        :param challenges: array of int shape(N,n)
+        :param challenges: array of int8 shape(N,n)
                            Array of challenges which should be evaluated by the simulation.
         :param k: int
                   Number of LTFArray PUFs
         :return:  array of int shape(N,k,n)
                   Array of transformed challenges.
         """
-
+        tools.assert_result_type(challenges)
         # Transform with ATF monomials
         challenges = transpose(
             array([
-                prod(challenges[:, i:], 1)
+                prod(challenges[:, i:], 1, dtype=tools.RESULT_TYPE)
                 for i in range(len(challenges[0]))
-            ])
+            ], dtype=tools.RESULT_TYPE)
         )
 
         # Same challenge for all k Arbiters
-        return cls.transform_id(challenges, k)
+        res = cls.transform_id(challenges, k)
+        tools.assert_result_type(res)
+        return res
 
     @staticmethod
     def transform_mm(challenges, k):
         """
         Input transformation that transforms nice.
-        :param challenges: array of int shape(N,n)
+        :param challenges: array of int8 shape(N,n)
                            Array of challenges which should be evaluated by the simulation.
         :param k: int
                   Number of LTFArray PUFs
-        :return:  array of int shape(N,k,n)
+        :return:  array of int8 shape(N,k,n)
                   Array of transformed challenges.
         """
+        tools.assert_result_type(challenges)
         N = len(challenges)
         n = len(challenges[0])
         assert k == 2, 'MM transform currently only implemented for k=2.'
@@ -112,19 +117,21 @@ class LTFArray(Simulation):
 
         result = swapaxes(dstack((cs_1, cs_2)), 1, 2)
         assert result.shape == (N, 2, n)
+        tools.assert_result_type(result)
         return result
 
     @classmethod
     def transform_lightweight_secure_original(cls, challenges, k):
         """
         Input transform as defined by Majzoobi et al. 2008.
-        :param challenges: array of int shape(N,n)
+        :param challenges: array of int8 shape(N,n)
                            Array of challenges which should be evaluated by the simulation.
         :param k: int
                   Number of LTFArray PUFs
-        :return:  array of int shape(N,k,n)
+        :return:  array of int8 shape(N,k,n)
                   Array of transformed challenges.
         """
+        tools.assert_result_type(challenges)
         N = len(challenges)
         n = len(challenges[0])
         assert n % 2 == 0, 'Secure Lightweight Input Transformation only defined for even n.'
@@ -136,12 +143,12 @@ class LTFArray(Simulation):
             array([
                 prod(cs_shift_trans[:, :, i:], 2)
                 for i in range(n)
-            ]),
+            ], dtype=tools.RESULT_TYPE),
             (1, 2, 0)
         )
 
         assert result.shape == (N, k, n), 'The resulting challenges have not the desired shape.'
-
+        tools.assert_result_type(result)
         return result
 
     @classmethod
@@ -149,13 +156,14 @@ class LTFArray(Simulation):
         """
         Input transform as defined by Majzoobi et al. 2008, but with the shift
         operation executed after and without ATF transform.
-        :param challenges: array of int shape(N,n)
+        :param challenges: array of int8 shape(N,n)
                            Array of challenges which should be evaluated by the simulation.
         :param k: int
                   Number of LTFArray PUFs
-        :return:  array of int shape(N,k,n)
+        :return:  array of int8 shape(N,k,n)
                   Array of transformed challenges.
         """
+        tools.assert_result_type(challenges)
         N = len(challenges)
         n = len(challenges[0])
         assert n % 2 == 0, 'Secure Lightweight Input Transformation only defined for even n.'
@@ -171,21 +179,23 @@ class LTFArray(Simulation):
         )
 
         assert challenges.shape == (N, n)
-
-        return cls.transform_shift(challenges, k)
+        res = cls.transform_shift(challenges, k)
+        tools.assert_result_type(res)
+        return res
 
     @classmethod
     def transform_shift_lightweight_secure(cls, challenges, k):
         """
         Input transform as defined by Majzoobi et al. 2008, with the shift
         operation executed first and without ATF transform.
-        :param challenges: array of int shape(N,n)
+        :param challenges: array of int8 shape(N,n)
                            Array of challenges which should be evaluated by the simulation.
         :param k: int
                   Number of LTFArray PUFs
-        :return:  array of int shape(N,k,n)
+        :return:  array of int8 shape(N,k,n)
                   Array of transformed challenges.
         """
+        tools.assert_result_type(challenges)
         N = len(challenges)
         n = len(challenges[0])
         assert n % 2 == 0, 'Secure Lightweight Input Transformation only defined for even n.'
@@ -204,7 +214,7 @@ class LTFArray(Simulation):
         )
 
         assert challenges.shape == (N, k, n)
-
+        tools.assert_result_type(challenges)
         return challenges
 
     @classmethod
@@ -212,13 +222,14 @@ class LTFArray(Simulation):
         """
         Input transformation like defined by Majzoobi et al. (cf. transform_lightweight_secure),
         but differs in one bit. Introduced by Sölter.
-        :param challenges: array of int shape(N,n)
+        :param challenges: array of int8 shape(N,n)
                            Array of challenges which should be evaluated by the simulation.
         :param k: int
                   Number of LTFArray PUFs
-        :return:  array of int shape(N,k,n)
+        :return:  array of int8 shape(N,k,n)
                   Array of transformed challenges.
         """
+        tools.assert_result_type(challenges)
         N = len(challenges)
         n = len(challenges[0])
         assert n % 2 == 0, 'Sölter\'s Secure Lightweight Input Transformation only defined for even n.'
@@ -235,21 +246,22 @@ class LTFArray(Simulation):
         )
 
         assert challenges.shape == (N, n)
-
-        return cls.transform_shift(challenges, k)
+        res = cls.transform_shift(challenges, k)
+        tools.assert_result_type(res)
+        return res
 
     @staticmethod
     def transform_shift(challenges, k):
         """
         Input transformation that shifts the input bits for each of the k PUFs.
-        :param challenges: array of int shape(N,n)
+        :param challenges: array of int8 shape(N,n)
                            Array of challenges which should be evaluated by the simulation.
         :param k: int
                   Number of LTFArray PUFs
-        :return:  array of int shape(N,k,n)
+        :return:  array of int8 shape(N,k,n)
                   Array of transformed challenges.
         """
-
+        tools.assert_result_type(challenges)
         N = len(challenges)
         n = len(challenges[0])
 
@@ -259,7 +271,7 @@ class LTFArray(Simulation):
         ]), 0, 1)
 
         assert result.shape == (N, k, n)
-
+        tools.assert_result_type(result)
         return result
 
     @classmethod
@@ -269,13 +281,14 @@ class LTFArray(Simulation):
         of the challenge shifted by i bits to the left, then input into inner product mod 2
         function.
         The other LTF get the original input.
-        :param challenges: array of int shape(N,n)
+        :param challenges: array of int8 shape(N,n)
                            Array of challenges which should be evaluated by the simulation.
         :param k: int
                   Number of LTFArray PUFs
-        :return:  array of int shape(N,k,n)
+        :return:  array of int8 shape(N,k,n)
                   Array of transformed challenges.
         """
+        tools.assert_result_type(challenges)
         N = len(challenges)
         n = len(challenges[0])
         assert n % 2 == 0, '1-n bent transform only defined for even n.'
@@ -292,8 +305,7 @@ class LTFArray(Simulation):
             )
         )
         assert bent_challenges.shape == (N, n)
-
-        return array([
+        res = array([
             concatenate(
                 (
                     [bent_challenges[j]],  # 'bent' challenge as generated above
@@ -302,7 +314,9 @@ class LTFArray(Simulation):
                 axis=0
             )
             for j in range(N)
-        ])
+        ], dtype=tools.RESULT_TYPE)
+        tools.assert_result_type(res)
+        return res
 
     @classmethod
     def transform_1_1_bent(cls, challenges, k):
@@ -311,13 +325,14 @@ class LTFArray(Simulation):
         the result of IPmod2 of the original challenge, all other input bits will
         remain the same.
         The other LTF get the original input.
-        :param challenges: array of int shape(N,n)
+        :param challenges: array of int8 shape(N,n)
                            Array of challenges which should be evaluated by the simulation.
         :param k: int
                   Number of LTFArray PUFs
-        :return:  array of int shape(N,k,n)
+        :return:  array of int8 shape(N,k,n)
                   Array of transformed challenges.
         """
+        tools.assert_result_type(challenges)
         N = len(challenges)
         n = len(challenges[0])
         assert k >= 2, '1-n bent transform currently only implemented for k>=2.'
@@ -325,8 +340,7 @@ class LTFArray(Simulation):
 
         bent_challenge_bits = cls.combiner_ip_mod2(challenges)
         assert bent_challenge_bits.shape == (N,)
-
-        return array([
+        res = array([
             concatenate(
                 (
                     [concatenate(([[bent_challenge_bits[j]], challenges[j][1:]]))],
@@ -336,7 +350,9 @@ class LTFArray(Simulation):
                 axis=0
             )
             for j in range(N)
-        ])
+        ], dtype=tools.RESULT_TYPE)
+        tools.assert_result_type(res)
+        return res
 
     @staticmethod
     def transform_polynomial(challenges, k):
@@ -348,14 +364,14 @@ class LTFArray(Simulation):
         of degree 8, 16, 24, 32, 48, or 64.
         Each Arbiter Chain i receives as input the polynomial c^i
         as element of GF(2^n).
-        :param challenges: array of int shape(N,n)
+        :param challenges: array of int8 shape(N,n)
                            Array of challenges which should be evaluated by the simulation.
         :param k: int
                   Number of LTFArray PUFs
-        :return:  array of int shape(N,k,n)
+        :return:  array of int8 shape(N,k,n)
                   Array of transformed challenges.
         """
-
+        tools.assert_result_type(challenges)
         N = len(challenges)
         n = len(challenges[0])
         assert n in [8, 16, 24, 32, 48, 64], 'Polynomial transformation is only implemented for challenges with n in ' \
@@ -363,37 +379,42 @@ class LTFArray(Simulation):
         if n == 64:
             irreducible_polynomial = array(
                 [1, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]
+                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
+                dtype=tools.RESULT_TYPE
             )
         elif n == 48:
             irreducible_polynomial = array(
                 [1, 0, 1, 1, 0, 1, 0, 0, 1, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0,
-                 1, 1, 0, 1, 0, 0, 1, 0, 1, 1, 0, 1, 0, 0, 1]
+                 1, 1, 0, 1, 0, 0, 1, 0, 1, 1, 0, 1, 0, 0, 1], dtype=tools.RESULT_TYPE
             )
         elif n == 32:
             irreducible_polynomial = array(
-                [1, 0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]
+                [1, 0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
+                dtype=tools.RESULT_TYPE
             )
         elif n == 24:
-            irreducible_polynomial = array([1, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
+            irreducible_polynomial = array([1, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
+                                           dtype=tools.RESULT_TYPE)
         elif n == 16:
-            irreducible_polynomial = array([1, 0, 1, 0, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 1, 1, 1])
+            irreducible_polynomial = array([1, 0, 1, 0, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 1, 1, 1], dtype=tools.RESULT_TYPE)
         elif n == 8:
-            irreducible_polynomial = array([1, 0, 1, 0, 0, 1, 1, 0, 1])
+            irreducible_polynomial = array([1, 0, 1, 0, 0, 1, 1, 0, 1], dtype=tools.RESULT_TYPE)
+        tools.assert_result_type(irreducible_polynomial)
 
         # Transform challenge to 0,1 array to compute transformation with numpy.
-        vtransform_to_01 = vectorize(tools.transform_challenge_11_to_01)
-        cs_01 = array([vtransform_to_01(c) for c in challenges])
+        cs_01 = array([tools.transform_challenge_11_to_01(c) for c in challenges])
 
         # Compute c^i for each challenge for i from 1 to k.
         challenges = concatenate([
             [tools.poly_mult_div(c, irreducible_polynomial, k) for c in cs_01]
         ])
+        tools.assert_result_type(challenges)
 
         # Transform challenges back to -1,1 notation.
-        result = array([tools.transform_challenge_01_to_11(c) for c in challenges])
+        result = array([tools.transform_challenge_01_to_11(c) for c in challenges], dtype=tools.RESULT_TYPE)
 
         assert result.shape == (N, k, n), 'The resulting challenges have not the desired shape.'
+        tools.assert_result_type(result)
         return result
 
     @staticmethod
@@ -401,13 +422,14 @@ class LTFArray(Simulation):
         """
         This transformation performs first a pseudorandom permutation of the challenge k times before applying the
         ATF transformation to each challenge.
-        :param challenges: array of int shape(N,n)
+        :param challenges: array of int8 shape(N,n)
                            Array of challenges which should be evaluated by the simulation.
         :param k: int
                   Number of LTFArray PUFs
-        :return:  array of int shape(N,k,n)
+        :return:  array of int8 shape(N,k,n)
                   Array of transformed challenges.
         """
+        tools.assert_result_type(challenges)
         N = len(challenges)
         n = len(challenges[0])
         seed = 0x1234
@@ -425,35 +447,35 @@ class LTFArray(Simulation):
             array([
                 prod(cs_permuted[:, :, i:], 2)
                 for i in range(n)
-            ]),
+            ], dtype=tools.RESULT_TYPE),
             (1, 2, 0)
         )
 
         assert result.shape == (N, k, n), 'The resulting challenges have not the desired shape.'
-
+        tools.assert_result_type(result)
         return result
 
     @staticmethod
     def transform_random(challenges, k):
         """
         This input transformation chooses for each Arbiter Chain an random challenge based on the initial challenge.
-        :param challenges: array of int shape(N,n)
+        :param challenges: array of int8 shape(N,n)
                            Array of challenges which should be evaluated by the simulation.
         :param k: int
                   Number of LTFArray PUFs
-        :return:  array of int shape(N,k,n)
+        :return:  array of int8 shape(N,k,n)
                   Array of transformed challenges.
         """
-
+        tools.assert_result_type(challenges)
         N = len(challenges)
         n = len(challenges[0])
 
-        vtransform_to_01 = vectorize(tools.transform_challenge_11_to_01)
-        cs_01 = array([vtransform_to_01(c) for c in challenges])
+        cs_01 = array([tools.transform_challenge_11_to_01(c) for c in challenges], dtype=tools.RESULT_TYPE)
 
-        result = array([RandomState(c).choice((-1, 1), (k, n)) for c in cs_01])
+        result = array([RandomState(c).choice((-1, 1), (k, n)) for c in cs_01], dtype=tools.RESULT_TYPE)
 
         assert result.shape == (N, k, n), 'The resulting challenges have not the desired shape.'
+        tools.assert_result_type(result)
         return result
 
     @staticmethod
@@ -474,13 +496,14 @@ class LTFArray(Simulation):
         def transform(challenges, k):
             """
            Method as described in generate_concatenated_transform doc string.
-           :param challenges: array of int shape(N,n)
+           :param challenges: array of int8 shape(N,n)
                               Array of challenges which should be evaluated by the simulation.
            :param k: int
                      Number of LTFArray PUFs
            :return: A function: array of int with shape(N,n), int number of PUFs k -> shape(N,k,n)
                     A function that can perform the desired transformation.
            """
+            tools.assert_result_type(challenges)
             (N, n) = challenges.shape
             transformed_1 = transform_1(challenges, puf_count)
             transformed_2 = transform_2(challenges, k - puf_count)
@@ -524,13 +547,14 @@ class LTFArray(Simulation):
         def transform(challenges, k):
             """
             Method as described in generate_concatenated_transform doc string.
-            :param challenges: array of int shape(N,n)
+            :param challenges: array of int8 shape(N,n)
                                Array of challenges which should be evaluated by the simulation.
             :param k: int
                      Number of LTFArray PUFs
             :return: A function: array of int with shape(N,n), int number of PUFs k -> shape(N,k,n)
                      A function that can perform the desired transformation.
             """
+            tools.assert_result_type(challenges)
             (_, n) = challenges.shape
             assert k == puf_count and n == challenge_length, \
                 'Permutations Input Transform cannot be used for LTFArrays with size other than defined'
@@ -577,13 +601,14 @@ class LTFArray(Simulation):
         def transform(challenges, k):
             """
             Method as described in generate_concatenated_transform doc string.
-            :param challenges: array of int shape(N,n)
+            :param challenges: array of int8 shape(N,n)
                                Array of challenges which should be evaluated by the simulation.
             :param k: int
                       Number of LTFArray PUFs
             :return: A function: array of int with shape(N,n), int number of PUFs k -> shape(N,k,n)
                      A function that can perform the desired transformation.
             """
+            tools.assert_result_type(challenges)
             (N, n) = challenges.shape
             challenges1 = challenges[:, :bit_number_transform_1]
             challenges2 = challenges[:, bit_number_transform_1:]
@@ -650,21 +675,25 @@ class LTFArray(Simulation):
     def eval(self, inputs):
         """
         evaluates a given array of challenges
-        :param inputs: array of challenges
-        :return: array of responses
+        :param inputs: array of int8 challenges
+        :return: array of int8 responses
         """
-        return sign(self.val(inputs))
+        tools.assert_result_type(inputs)
+        res = (sign(self.val(inputs))).astype(tools.RESULT_TYPE)
+        tools.assert_result_type(res)
+        return res
 
     def val(self, inputs):
         """
         This method evaluates a given array of challenges.
         It composes several parts of the LTFArray simulation in order
         to return a array of combined responses. The responses are positive and negative float values.
-        :param inputs: array of int shape(N,n)
+        :param inputs: array of int8 shape(N,n)
                        Array of challenges which should be evaluated by the simulation.
         :return: array of float or int depending on the combiner shape(N)
                  Array of responses for the N different challenges.
         """
+        tools.assert_result_type(inputs)
         return self.combiner(self.ltf_eval(self.transform(inputs, self.k)))
 
     def ltf_eval(self, inputs):
@@ -676,6 +705,7 @@ class LTFArray(Simulation):
         :return: array of int shape(N,k)
                  Array of responses for the N different challenges.
         """
+        tools.assert_result_type(inputs)
         if self.bias is not None:
             responses = ph.eval(tools.append_last(inputs, 1), self.weight_array)
         else:
@@ -818,6 +848,7 @@ class SimulationMajorityLTFArray(LTFArray):
         :return: array of int shape(N)
                  Array of responses for the N different challenges.
         """
+        tools.assert_result_type(inputs)
         return self.combiner(self.majority_vote(self.transform(inputs, self.k)))
 
     def majority_vote(self, transformed_inputs):

--- a/pypuf/tools.py
+++ b/pypuf/tools.py
@@ -4,26 +4,26 @@ or polynomial division. The spectrum is rich and the functions are used in many 
 helper module.
 """
 import itertools
-from numpy import count_nonzero, array, append, zeros, vstack, mean, prod, ones, dtype, full, shape
+from numpy import count_nonzero, array, append, zeros, vstack, mean, prod, ones, dtype, full, shape, copy
 from numpy import sum as np_sum
 from numpy import abs as np_abs
 from numpy.random import RandomState
 
+RESULT_TYPE = 'int8'
+
 
 def random_input(n, random_instance=RandomState()):
     """
-    This method generates an array with random interger.
+    This method generates an array with random integer.
     By default a fresh `numpy.random.RandomState`instance is used.
     :param n: int
               Number of bits which should be generated
     :param random_instance: numpy.random.RandomState
                             The PRNG which is used to generate the output bits.
-    :returns: array of int
+    :returns: array of int8
               A pseudo random array of -1 and 1
-
-
     """
-    return random_instance.choice((-1, +1), n)
+    return (random_instance.choice((-1, +1), n)).astype(RESULT_TYPE)
 
 
 def all_inputs(n):
@@ -31,10 +31,10 @@ def all_inputs(n):
     This functions generates a iterator which produces all possible {-1,1}-vectors.
     :param int
            Length of a n bit vector
-    :returns: iterator of {-1,1} int arrays
-              An iterator with all possible different {-1,1}-vectors of length `n`.
+    :returns: array of int8
+              An array with all possible different {-1,1}-vectors of length `n`.
     """
-    return itertools.product((-1, +1), repeat=n)
+    return (array(list(itertools.product((-1, +1), repeat=n)))).astype(RESULT_TYPE)
 
 
 def random_inputs(n, num, random_instance=RandomState()):
@@ -47,11 +47,13 @@ def random_inputs(n, num, random_instance=RandomState()):
                 Number of n bit vector
     :param random_instance: numpy.random.RandomState
                             The PRNG which is used to generate the arrays.
-    :return: iterator of num {-1,1} int arrays
-             An iterator with num random {-1,1} int arrays.
+    :return: array of num {-1,1} int8 arrays
+             An array with num random {-1,1} int arrays.
     """
-    for _ in range(num):
-        yield random_input(n, random_instance)
+    res = zeros((num, n), dtype=RESULT_TYPE)
+    for i in range(num):
+        res[i] = random_input(n, random_instance=random_instance)
+    return res
 
 
 def sample_inputs(n, num, random_instance=RandomState()):
@@ -66,23 +68,10 @@ def sample_inputs(n, num, random_instance=RandomState()):
                 Number of n bit vector
     :param random_instance: numpy.random.RandomState
                             The PRNG which is used to generate the arrays.
-    :return: iterator of num {-1,1} int arrays
-             An iterator with num random {-1,1} int arrays depending on num and n.
+    :return: array of num {-1,1} int8 arrays
+             An array with num random {-1,1} int arrays depending on num and n.
     """
     return random_inputs(n, num, random_instance) if num < 2 ** n else all_inputs(n)
-
-
-def iter_append_last(array_iterator, item):
-    """
-    :param array_iterator: iterator of arbitrary type
-                           Iterator where an item should be appended.
-    :param item: of arbitrary type equal to iterator type
-                 Item which should be appended.
-    :returns: iterator of arbitrary type
-              An iterator for a given iterator of arrays to which an item will be appended.
-    """
-    for array_obj in array_iterator:
-        yield append(array_obj, item)
 
 
 def append_last(arr, item):
@@ -95,7 +84,6 @@ def append_last(arr, item):
     :return: n dimensional array of type
              initial arr with appended element item
     """
-    assert arr.dtype == dtype(type(item)), 'The elements of arr and item must be of the same type.'
     dimension = list(shape(arr))
     assert len(dimension) >= 1, 'arr must have at least one dimension.'
     # the lowest level should contain one item
@@ -121,7 +109,7 @@ def approx_dist(instance1, instance2, num, random_instance=RandomState()):
              Probability (randomly uniform x) for instance1.eval(x) != instance2.eval(x)
     """
     assert instance1.n == instance2.n
-    inputs = array(list(random_inputs(instance1.n, num, random_instance)))
+    inputs = random_inputs(instance1.n, num, random_instance=random_instance)
     return (num - count_nonzero(instance1.eval(inputs) == instance2.eval(inputs))) / num
 
 
@@ -129,30 +117,34 @@ def approx_fourier_coefficient(s, training_set):
     """
     Approximate the Fourier coefficient of a function on the subset `s`
     by evaluating the function on `training_set`
-    :param s: list of int
+    :param s: list of int8
                   A {0,1}-array indicating the coefficient's index set
     :param training_set: pypuf.tools.TrainingSet
     :return: float
              The approximated value of the coefficient
     """
+    assert_result_type(s)
+    assert_result_type(training_set.challenges)
     return mean(training_set.responses * chi_vectorized(s, training_set.challenges))
 
 
 def chi_vectorized(s, inputs):
     """
     Parity function of inputs on indices in s.
-    :param s: list of int
+    :param s: list of int8
               A {0,1}-array indicating the index set
-    :param inputs: array of int shape(N,n)
+    :param inputs: array of int8 shape(N,n)
                    {-1,1}-valued inputs to be evaluated.
-    :return: array of int shape(N)
+    :return: array of int8 shape(N)
              chi_s(x) = prod_(i in s) x_i for all x in inputs (`latex formula`)
     """
+    assert_result_type(s)
+    assert_result_type(inputs)
     assert len(s) == len(inputs[0])
     result = inputs[:, s > 0]
     if result.size == 0:
-        return ones(len(inputs))
-    return prod(result, axis=1)
+        return ones(len(inputs), dtype=RESULT_TYPE)
+    return prod(result, axis=1, dtype=RESULT_TYPE)
 
 
 def compare_functions(function1, function2):
@@ -172,34 +164,32 @@ def compare_functions(function1, function2):
 
 def transform_challenge_01_to_11(challenge):
     """
-    This function is meant to be used with the numpy vectorize method.
-    After vectorizing, transform_challenge_01_to_11 can be applied to
-    numpy arrays to transform a challenge from 0,1 notation to -1,1 notation.
-    :param challenge: array of int
+    This function is used to transform a challenge from 0,1 notation to -1,1 notation.
+    :param challenge: array of int8
                       Challenge vector in 0,1 notation
-    :return: array of int
+    :return: array of int8
              Same vector in -1,1 notation
     """
-    if (challenge % 2) == 0:
-        return 1
-    else:
-        return -1
+    assert_result_type(challenge)
+    res = copy(challenge)
+    res[res == 1] = -1
+    res[res == 0] = 1
+    return res
 
 
 def transform_challenge_11_to_01(challenge):
     """
-    This function is meant to be used with the numpy vectorize method.
-    After vectorizing, transform_challenge_11_to_01 can be applied to
-    numpy arrays to transform a challenge from -1,1 notation to 0,1 notation.
-    :param challenge: array of int
+    This function is used to transform a challenge from -1,1 notation to 0,1 notation.
+    :param challenge: array of int8
                       Challenge vector in -1,1 notation
-    :return: array of int
+    :return: array of int8
              Same vector in 0,1 notation
     """
-    if challenge == 1:
-        return 0
-    else:
-        return 1
+    assert_result_type(challenge)
+    res = copy(challenge)
+    res[res == 1] = 0
+    res[res == -1] = 1
+    return res
 
 
 def poly_mult_div(challenge, irreducible_polynomial, k):
@@ -207,26 +197,29 @@ def poly_mult_div(challenge, irreducible_polynomial, k):
     Return the list of polynomials
         [challenge^2, challenge^3, ..., challenge^(k+1)] mod irreducible_polynomial
     based on the challenge challenge and the irreducible polynomial irreducible_polynomial.
-    :param challenge: array of int
+    :param challenge: array of int8
                       Challenge vector in 0,1 notation
-    :param irreducible_polynomial: array of int
+    :param irreducible_polynomial: array of int8
                                    Vector in 0,1 notation
     :param k: int
               Number of PUFs
-    :return: array of int
+    :return: array of int8
              Array of polynomials
     """
     import polymath as pm
-
+    assert_result_type(challenge)
+    assert_result_type(irreducible_polynomial)
     c_original = challenge
     res = None
     for i in range(k):
         challenge = pm.polymul(challenge, c_original)
         challenge = pm.polymodpad(challenge, irreducible_polynomial)
         if i == 0:
-            res = array([challenge])
+            res = array([challenge], dtype=RESULT_TYPE)
         else:
             res = vstack((res, challenge))
+    res = res.astype(RESULT_TYPE)
+    assert_result_type(res)
     return res
 
 
@@ -249,9 +242,16 @@ def approx_stabilities(instance, num, reps, random_instance=RandomState()):
     challenges = sample_inputs(instance.n, num, random_instance)
     responses = zeros((reps, num))
     for i in range(reps):
-        challenges, unpacked_challenges = itertools.tee(challenges)
-        responses[i, :] = instance.eval(array(list(unpacked_challenges)))
+        responses[i, :] = instance.eval(challenges)
     return 0.5 + 0.5 * np_abs(np_sum(responses, axis=0)) / reps
+
+
+def assert_result_type(arr):
+    """
+    This function checks the type of the array to match the RESULT_TYPE
+    :param arr: array of arbitrary type
+    """
+    assert arr.dtype == dtype(RESULT_TYPE), 'Must be an array of {0}. Got array of {1}'.format(RESULT_TYPE, arr.dtype)
 
 
 class TrainingSet():
@@ -270,6 +270,6 @@ class TrainingSet():
                                 PRNG which is used to draft challenges.
         """
         self.instance = instance
-        self.challenges = array(list(sample_inputs(instance.n, N, random_instance=random_instance)))
+        self.challenges = sample_inputs(instance.n, N, random_instance=random_instance)
         self.responses = instance.eval(self.challenges)
         self.N = N

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy==1.13.*
 pep8==1.7.*
-polymath==0.1.17
+polymath==0.1.18
 pylint==1.7.*
-pypuf-helper==0.1.4
+pypuf-helper==0.1.5
 scipy==0.19.*
 astroid==1.5.*

--- a/test/test_experiment.py
+++ b/test/test_experiment.py
@@ -73,10 +73,12 @@ class TestExperimentLogisticRegression(TestBase):
             exp_1_result_log.close()
             exp_2_result_log.close()
             # Check the results to be not empty
-            self.assertFalse(result_1 == '', 'The experiment log was empty.')
-            self.assertFalse(result_2 == '', 'The experiment log was empty.')
+            self.assertFalse(result_1 == '', 'The experiment {0} log was empty.'.format(experiment_1.log_name))
+            self.assertFalse(result_2 == '', 'The experiment log {0} was empty.'.format(experiment_2.log_name))
             # Compare logs
-            self.assertTrue(result_1 == result_2, 'The results must be equal.')
+            self.assertTrue(result_1 == result_2,
+                            'The results of {0} and {1} must be equal.'.format(experiment_1.log_name,
+                                                                               experiment_2.log_name))
 
         def get_exp(name, k, trans, comb):
             """Experiment creation shortcut

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -1,6 +1,6 @@
 """This module tests the different functions which can be used to determine simulation properties."""
 import unittest
-from numpy import array, mean, reshape, repeat
+from numpy import mean, reshape, repeat
 from numpy.testing import assert_array_equal
 from numpy.random import RandomState
 from pypuf.simulation.arbiter_based.ltfarray import LTFArray, NoisyLTFArray
@@ -23,7 +23,7 @@ class TestPropertyTest(unittest.TestCase):
             transform=transformation,
             combiner=combiner,
         )
-        challenges = array(list(sample_inputs(n, N, random_instance=RandomState(0xFAB1A))))
+        challenges = sample_inputs(n, N, random_instance=RandomState(0xFAB1A))
         reliabilities = []
         for challenge in challenges:
             reliabilities.append(PropertyTest.reliability(instance, reshape(challenge, (1, n))))
@@ -35,11 +35,11 @@ class TestPropertyTest(unittest.TestCase):
             weight_array=NoisyLTFArray.normal_weights(n=n, k=k, random_instance=RandomState(0xA1A1)),
             transform=transformation,
             combiner=combiner,
-            sigma_noise=0.5,
+            sigma_noise=15.0,
             random_instance=RandomState(0x5015E),
         )
         for challenge in challenges:
-            reliability = PropertyTest.reliability(noisy_instance, challenge)
+            reliability = PropertyTest.reliability(noisy_instance, reshape(challenge, (1, n)))
             # For noisy simulations the responses should vary
             self.assertNotEqual(reliability, 0.0)
 
@@ -61,7 +61,7 @@ class TestPropertyTest(unittest.TestCase):
             )
             instances.append(instance)
 
-        challenges = array(list(sample_inputs(n, N, random_instance=RandomState(0xFAB0))))
+        challenges = sample_inputs(n, N, random_instance=RandomState(0xFAB0))
 
         reliability_set = PropertyTest.reliability_set(instances, challenges, measurements=measurements)
         # The result is an array like with N * k entries.
@@ -99,7 +99,7 @@ class TestPropertyTest(unittest.TestCase):
                      transform=transformation, combiner=combiner) for i in range(instance_count)
         ]
 
-        challenges = array(list(sample_inputs(n, N, random_instance=RandomState(0xFAB10))))
+        challenges = sample_inputs(n, N, random_instance=RandomState(0xFAB10))
 
         property_test = PropertyTest(instances)
         reliability_statistic = property_test.reliability_statistic(challenges, measurements=measurements)
@@ -140,7 +140,7 @@ class TestPropertyTest(unittest.TestCase):
             LTFArray(weight_array=LTFArray.normal_weights(n=n, k=k, random_instance=RandomState(0xA1A1 + i)),
                      transform=transformation, combiner=combiner) for i in range(instance_count)
         ]
-        challenges = array(list(sample_inputs(n, N, random_instance=RandomState(0xFAB10))))
+        challenges = sample_inputs(n, N, random_instance=RandomState(0xFAB10))
         uniqueness = []
         for challenge in challenges:
             uniqueness.append(PropertyTest.uniqueness(instances, reshape(challenge, (1, n))))
@@ -160,7 +160,7 @@ class TestPropertyTest(unittest.TestCase):
             LTFArray(weight_array=LTFArray.normal_weights(n=n, k=k, random_instance=RandomState(0xA1A1 + i)),
                      transform=transformation, combiner=combiner) for i in range(instance_count)
         ]
-        challenges = array(list(sample_inputs(n, N, random_instance=RandomState(0xFAB10))))
+        challenges = sample_inputs(n, N, random_instance=RandomState(0xFAB10))
 
         uniqueness_set = PropertyTest.uniqueness_set(instances, challenges, measurements=measurements)
 
@@ -184,7 +184,7 @@ class TestPropertyTest(unittest.TestCase):
                      transform=transformation, combiner=combiner) for i in range(instance_count)
         ]
 
-        challenges = array(list(sample_inputs(n, N, random_instance=RandomState(0xFAB10))))
+        challenges = sample_inputs(n, N, random_instance=RandomState(0xFAB10))
 
         property_test = PropertyTest(instances)
         uniqueness_statistic = property_test.uniqueness_statistic(challenges, measurements=measurements)

--- a/test/test_simulation.py
+++ b/test/test_simulation.py
@@ -489,7 +489,7 @@ class TestLTFArray(unittest.TestCase):
         mu = 1
         sigma = 0.5
 
-        challenges = array(list(tools.all_inputs(n)))
+        challenges = tools.all_inputs(n)
 
         weight_array = LTFArray.normal_weights(n, k, mu=mu, sigma=sigma, random_instance=RandomState(0xBADA556))
         bias_value = 2.5
@@ -529,7 +529,7 @@ class TestLTFArray(unittest.TestCase):
         mu = 1
         sigma = 0.5
 
-        challenges = array(list(tools.all_inputs(n)))
+        challenges = tools.all_inputs(n)
 
         weight_array = LTFArray.normal_weights(n, k, mu=mu, sigma=sigma, random_instance=RandomState(0xBADA556))
         bias_array = LTFArray.normal_weights(1, k, mu=mu, sigma=sigma*2, random_instance=RandomState(0xBADAFF1))
@@ -669,7 +669,7 @@ class TestNoisyLTFArray(TestLTFArray):
         mu = 1
         sigma = 0.5
 
-        challenges = array(list(tools.all_inputs(n)))
+        challenges = tools.all_inputs(n)
 
         weight_array = NoisyLTFArray.normal_weights(n, k, mu=mu, sigma=sigma, random_instance=RandomState(0xBADA556))
         bias_array = NoisyLTFArray.normal_weights(1, k, mu=mu, sigma=sigma * 2, random_instance=RandomState(0xBADAFF1))
@@ -712,7 +712,7 @@ class TestNoisyLTFArray(TestLTFArray):
         mu = 1
         sigma = 0.5
 
-        challenges = array(list(tools.all_inputs(n)))
+        challenges = tools.all_inputs(n)
 
         weight_array = NoisyLTFArray.normal_weights(n, k, mu=mu, sigma=sigma, random_instance=RandomState(0xBADA556))
         bias_value = 2.5
@@ -795,7 +795,7 @@ class TestSimulationMajorityLTFArray(unittest.TestCase):
             combiner=LTFArray.combiner_xor
         )
 
-        inputs = array(list(tools.random_inputs(n, crp_count, random_instance=RandomState(seed=0xDEADDA7A))))
+        inputs = tools.random_inputs(n, crp_count, random_instance=RandomState(seed=0xDEADDA7A))
 
         ltf_array_result = ltf_array.eval(inputs)
         mv_noisy_ltf_array_result = mv_noisy_ltf_array.eval(inputs)
@@ -832,7 +832,7 @@ class TestSimulationMajorityLTFArray(unittest.TestCase):
         vote_count = 1
         weight_array = LTFArray.normal_weights(n, k, mu, sigma, weight_prng1)
 
-        inputs = array(list(tools.random_inputs(n, crp_count, random_instance=RandomState(seed=0xDEADDA7A))))
+        inputs = tools.random_inputs(n, crp_count, random_instance=RandomState(seed=0xDEADDA7A))
 
         combiners = get_functions_with_prefix('combiner_', SimulationMajorityLTFArray)
         transformations = get_functions_with_prefix('transform_', SimulationMajorityLTFArray)
@@ -858,7 +858,7 @@ class TestSimulationMajorityLTFArray(unittest.TestCase):
         mu = 1
         sigma = 0.5
 
-        challenges = challenges = array(list(tools.all_inputs(n)))
+        challenges = challenges = tools.all_inputs(n)
 
         weight_array = SimulationMajorityLTFArray.normal_weights(n, k, mu=mu, sigma=sigma,
                                                                  random_instance=RandomState(0xBADA556))
@@ -905,7 +905,7 @@ class TestSimulationMajorityLTFArray(unittest.TestCase):
         mu = 1
         sigma = 0.5
 
-        challenges = array(list(tools.all_inputs(n)))
+        challenges = tools.all_inputs(n)
 
         weight_array = SimulationMajorityLTFArray.normal_weights(n, k, mu=mu, sigma=sigma,
                                                                  random_instance=RandomState(0xBADA556))

--- a/test/test_simulation.py
+++ b/test/test_simulation.py
@@ -69,7 +69,7 @@ class TestInputTransformation(unittest.TestCase):
         This method test the identity function for the predefined inputs (challenges). If every challenge is duplicated
         k times the function works correct.
         """
-        test_challenges = [
+        test_challenges = array([
             [
                 [-1, 1, 1, -1, -1],
                 [-1, -1, -1, -1, -1],
@@ -85,7 +85,7 @@ class TestInputTransformation(unittest.TestCase):
                 [-1, -1, -1, -1, -1],
                 [-1, 1, -1, -1, -1],
             ]
-        ]
+        ], dtype=tools.RESULT_TYPE)
         for challenges in test_challenges:
             assert_array_equal(
                 LTFArray.transform_id(challenges, k=4),
@@ -120,7 +120,7 @@ class TestInputTransformation(unittest.TestCase):
             [1, 1, 1, -1, -1],
             [-1, -1, -1, -1, -1],
             [-1, 1, -1, -1, -1],
-        ])
+        ], dtype=tools.RESULT_TYPE)
         assert_array_equal(
             LTFArray.transform_atf(test_array, k=3),
             [
@@ -165,7 +165,7 @@ class TestInputTransformation(unittest.TestCase):
             [1, 1, -1, -1, -1],
             [1, 1, -1, -1, -1],
             [1, 2, 3, 4, 5],
-        ])
+        ], dtype=tools.RESULT_TYPE)
         assert_array_equal(
             LTFArray.transform_shift(test_array, k=3),
             [
@@ -202,7 +202,7 @@ class TestInputTransformation(unittest.TestCase):
         test_array = array([
             [1, -1, -1, 1, -1, 1],
             [-1, 1, 1, -1, -1, 1],
-        ])
+        ], dtype=tools.RESULT_TYPE)
         assert_array_equal(
             LTFArray.transform_lightweight_secure(test_array, k=3),
             [
@@ -223,7 +223,7 @@ class TestInputTransformation(unittest.TestCase):
         """This method tests the shift secure lightweight transformation with predefined input and output."""
         test_array = array([
             [1, -1, -1, 1, -1, 1],
-        ])
+        ], dtype=tools.RESULT_TYPE)
         assert_array_equal(
             LTFArray.transform_shift_lightweight_secure(test_array, k=3),
             [
@@ -240,7 +240,7 @@ class TestInputTransformation(unittest.TestCase):
         test_array = array([
             [1, -1, -1, 1, -1, 1],
             [-1, 1, 1, -1, -1, 1],
-        ])
+        ], dtype=tools.RESULT_TYPE)
         assert_array_equal(
             LTFArray.transform_1_n_bent(test_array, k=3),
             [
@@ -259,7 +259,7 @@ class TestInputTransformation(unittest.TestCase):
         test_array = array([
             [1, -1, -1, 1, -1, 1],
             [-1, 1, 1, -1, -1, 1],
-        ])
+        ], dtype=tools.RESULT_TYPE)
         assert_array_equal(
             LTFArray.transform_1_n_bent(test_array, k=1),
             [
@@ -279,7 +279,7 @@ class TestInputTransformation(unittest.TestCase):
         test_array = array([
             [1, -1, 1, -1],
             [-1, -1, 1, -1],
-        ])
+        ], dtype=tools.RESULT_TYPE)
         assert_array_equal(
             LTFArray.generate_stacked_transform(
                 transform_1=LTFArray.transform_id,
@@ -307,7 +307,7 @@ class TestInputTransformation(unittest.TestCase):
         test_array = array([
             [1, 2, 3, 4],
             [10, 20, 30, 40],
-        ])
+        ], dtype=tools.RESULT_TYPE)
         assert_array_equal(
             LTFArray.generate_random_permutation_transform(
                 seed=0xbeef,
@@ -354,7 +354,7 @@ class TestInputTransformation(unittest.TestCase):
         """
         test_array = array([
             [1, -1, -1, 1, -1, 1, -1, 1, 1, -1, -1],
-        ])
+        ], dtype=tools.RESULT_TYPE)
         assert_array_equal(
             LTFArray.generate_concatenated_transform(
                 transform_1=LTFArray.transform_1_n_bent,
@@ -375,7 +375,7 @@ class TestInputTransformation(unittest.TestCase):
         test_array = array([
             [1, -1, -1, 1, -1, 1],
             [-1, 1, 1, -1, -1, 1],
-        ])
+        ], dtype=tools.RESULT_TYPE)
         assert_array_equal(
             LTFArray.transform_1_1_bent(test_array, k=3),
             [
@@ -399,7 +399,7 @@ class TestInputTransformation(unittest.TestCase):
              1, 1, -1, 1, -1, -1, 1, 1, -1, 1, -1, -1, 1, -1, 1, 1, 1,
              1, 1, -1, 1, 1, 1, 1, 1, -1, 1, 1, 1, 1, 1, -1, 1, -1,
              1, -1, -1, -1, 1, 1, 1, -1, 1, 1, -1, 1, 1]
-        ])
+        ], dtype=tools.RESULT_TYPE)
         assert_array_equal(
             LTFArray.transform_polynomial(test_array, k=4),
             [
@@ -427,7 +427,7 @@ class TestInputTransformation(unittest.TestCase):
              1, 1, -1, 1, -1, -1, 1, 1, -1, 1, -1, -1, 1, -1, 1, 1, 1,
              1, 1, -1, 1, 1, 1, 1, 1, -1, 1, 1, 1, 1, 1, -1, 1, -1,
              1, -1, -1, -1, 1, 1, 1, -1, 1, 1, -1, 1, 1]
-        ])
+        ], dtype=tools.RESULT_TYPE)
         assert_array_equal(
             LTFArray.transform_polynomial(test_array, k=1),
             [
@@ -444,7 +444,7 @@ class TestInputTransformation(unittest.TestCase):
         test_array = array([
             [1, -1, -1, 1, -1, 1],
             [-1, 1, 1, -1, -1, 1],
-        ])
+        ], dtype=tools.RESULT_TYPE)
         assert_array_equal(
             LTFArray.transform_permutation_atf(test_array, k=4),
             [
@@ -592,7 +592,7 @@ class TestLTFArray(unittest.TestCase):
             mu = test_parameters[2]
             sigma = test_parameters[3]
 
-            inputs = RandomState(seed=0xCAFED00D).choice([-1, +1], (N, n))
+            inputs = tools.random_inputs(n, N, random_instance=RandomState(0xA1))
 
             ltf_array = LTFArray(
                 weight_array=LTFArray.normal_weights(n, k, mu, sigma),
@@ -634,7 +634,7 @@ class TestNoisyLTFArray(TestLTFArray):
             sigma = test_parameters[3]
 
             transformed_inputs = LTFArray.transform_id(
-                RandomState(seed=0xBAADA555).choice([-1, +1], (N, n)),  # bad ass testing
+                tools.random_inputs(n, N, random_instance=RandomState(seed=0xBAADA555)),
                 k
             )
 
@@ -799,6 +799,8 @@ class TestSimulationMajorityLTFArray(unittest.TestCase):
 
         ltf_array_result = ltf_array.eval(inputs)
         mv_noisy_ltf_array_result = mv_noisy_ltf_array.eval(inputs)
+        print(ltf_array_result)
+        print(mv_noisy_ltf_array_result)
         # These test checks if the output is different because of noise
         self.assertFalse(array_equal(ltf_array_result, mv_noisy_ltf_array_result), 'These arrays must be different')
 
@@ -858,7 +860,7 @@ class TestSimulationMajorityLTFArray(unittest.TestCase):
         mu = 1
         sigma = 0.5
 
-        challenges = challenges = tools.all_inputs(n)
+        challenges = tools.all_inputs(n)
 
         weight_array = SimulationMajorityLTFArray.normal_weights(n, k, mu=mu, sigma=sigma,
                                                                  random_instance=RandomState(0xBADA556))
@@ -937,6 +939,6 @@ class TestSimulationMajorityLTFArray(unittest.TestCase):
 
         biased_responses = biased_ltf_array.eval(challenges)
         responses = ltf_array.eval(challenges)
-
-        # The arithmetic mean of the res
+        print(biased_responses)
+        print(responses)
         self.assertFalse(array_equal(biased_responses, responses))

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -1,25 +1,15 @@
 """This module is used to test the functions which are implemented in pypuf.tools."""
 import unittest
-from numpy import zeros, dtype, array_equal
+from numpy import zeros, dtype, array_equal, array
 from numpy.random import RandomState
+from numpy.testing import assert_array_equal
 from pypuf.simulation.arbiter_based.ltfarray import LTFArray
-from pypuf.tools import append_last, TrainingSet
+from pypuf.tools import random_input, all_inputs, random_inputs, sample_inputs, chi_vectorized, append_last, \
+    TrainingSet, RESULT_TYPE, transform_challenge_11_to_01, transform_challenge_01_to_11, poly_mult_div
 
 
 class TestAppendLast(unittest.TestCase):
     """This class is used to test the append_last method from tools."""
-    def test_same_dtype(self):
-        """This function checks for type safety"""
-        typ = dtype('int64')
-        arr = zeros((3, 2, 1), dtype=typ)
-        item = 30
-        arr_res = append_last(arr, item)
-        self.assertEqual(arr_res.dtype, typ, 'The types must be equal.')
-
-        arr = zeros((3, 2, 1), dtype=typ)
-        item = 30.1
-        with self.assertRaisesRegex(AssertionError, 'The elements of arr and item must be of the same type.'):
-            append_last(arr, item)
 
     def test_proper_dimension(self):
         """The function recognizes that the array has dimension zero."""
@@ -49,7 +39,7 @@ class TestAppendLast(unittest.TestCase):
             # generate the shape of the array which is used to check the adding
             shape_res = [i for i in range(dimensions)]
             # the last dimension must have one more element than the last dimension of arr
-            shape_res[-1] = shape_res[-1]+1
+            shape_res[-1] = shape_res[-1] + 1
             # generate the arrays
             arr_check = zeros(shape_res, dtype=typ)
             arr = zeros(shape, dtype=typ)
@@ -83,3 +73,97 @@ class TestAppendLast(unittest.TestCase):
             array_equal(training_set_1.challenges, training_set_2.challenges),
             'The challenges are not equal.',
         )
+
+
+class TestInputFunctions(unittest.TestCase):
+    """This Class tests the different challenge calculating functions."""
+
+    def test_random_input(self):
+        """This checks the shape, type  and values of the returned array."""
+        n = 8
+        rand_arr = random_input(n, random_instance=RandomState(0x5A11B))
+        self.assertEqual(len(rand_arr), n, 'Array must be of length n.')
+        self.assertEqual(rand_arr.dtype, dtype(RESULT_TYPE), 'Array must be of type {0}'.format(RESULT_TYPE))
+
+        array_sum = sum(rand_arr)
+        # Checks for different values
+        self.assertNotEqual(array_sum, n, 'All values are 1.')
+        self.assertNotEqual(array_sum, 0, 'All values are 0.')
+        self.assertGreater(array_sum, 0, 'The array should contain positive values only.')
+
+    def test_all_inputs(self):
+        """This checks the shape and type of the returned multidimensional array."""
+        n = 8
+        N = 2 ** n
+        arr = all_inputs(n)
+        self.check_multi_dimensional_array(arr, N, n, RESULT_TYPE)
+
+    def test_random_inputs(self):
+        """This checks the shape and type of the returned multidimensional array."""
+        n = 8
+        N = 2 ** (int(n / 2))
+        rand_arrays = random_inputs(n, N)
+        self.check_multi_dimensional_array(rand_arrays, N, n, RESULT_TYPE)
+
+    def test_sample_inputs(self):
+        """This checks the shape and type of the returned multidimensional array."""
+        n = 8
+        N = 2 ** n
+        all_arr = sample_inputs(n, N)
+        self.check_multi_dimensional_array(all_arr, N, n, RESULT_TYPE)
+
+        N = 2 ** int(n / 2)
+        rand_arr = sample_inputs(n, N)
+        self.check_multi_dimensional_array(rand_arr, N, n, RESULT_TYPE)
+
+    def test_transform_challenge_01_to_11(self):
+        """This function checks the correct behavior of the challenge transformation."""
+        challenge_01 = array([0, 1, 0, 1, 1, 0, 0, 0], dtype=RESULT_TYPE)
+        challenge_11 = array([1, -1, 1, -1, -1, 1, 1, 1], dtype=RESULT_TYPE)
+        transformed_challenge = transform_challenge_01_to_11(challenge_01)
+        assert_array_equal(challenge_11, transformed_challenge)
+        self.assertEqual(transformed_challenge.dtype, dtype(RESULT_TYPE),
+                         'The array is not of type {0}.'.format(RESULT_TYPE))
+
+    def test_transform_challenge_11_to_01(self):
+        """This function checks the correct behavior of the challenge transformation."""
+        challenge_11 = array([-1, 1, 1, 1, -1, 1, -1, 1], dtype=RESULT_TYPE)
+        challenge_01 = array([1, 0, 0, 0, 1, 0, 1, 0], dtype=RESULT_TYPE)
+        transformed_challenge = transform_challenge_11_to_01(challenge_11)
+        assert_array_equal(challenge_01, transformed_challenge)
+        self.assertEqual(transformed_challenge.dtype, dtype(RESULT_TYPE),
+                         'The array is not of type {0}.'.format(RESULT_TYPE))
+
+    def test_chi_vectorized(self):
+        """This function checks the return type of this function."""
+        n = 8
+        N = 2 ** int(n / 2)
+        s = random_input(n)
+        inputs = random_inputs(n, N)
+        chi_arr = chi_vectorized(s, inputs)
+        self.assertEqual(len(chi_arr), N, 'The array must contain {0} arrays.'.format(N))
+        self.assertEqual(chi_arr.dtype, RESULT_TYPE, 'The array must be of type {0}'.format(RESULT_TYPE))
+
+    def test_poly_mult_div(self):
+        """This method checks the shape and type of two dimensional arrays."""
+        n = 8
+        k = 2
+        N = 2 ** int(n / 2)
+        challenges_11 = random_inputs(n, N)
+        challenges_01 = array([transform_challenge_11_to_01(c) for c in challenges_11], dtype=RESULT_TYPE)
+        irreducible_polynomial = array([1, 0, 1, 0, 0, 1, 1, 0, 1], dtype=RESULT_TYPE)
+        poly_mult_div(challenges_01, irreducible_polynomial, k)
+        self.check_multi_dimensional_array(challenges_01, N, n, RESULT_TYPE)
+
+    def check_multi_dimensional_array(self, arr, arr_size, sub_arr_size, arr_type):
+        """This method checks the shape and type of two dimensional arrays.
+        :param arr: array of type arr_type
+        :param arr_size: int
+        :param sub_arr_size: int
+        :param arr_type: string of numpy.dtype
+        """
+        self.assertEqual(len(arr), arr_size, 'The array must contain {0} arrays.'.format(arr_size))
+        for i in range(arr_size):
+            self.assertEqual(len(arr[i]), sub_arr_size,
+                             'The sub array does not match the length of {0}.'.format(sub_arr_size))
+            self.assertEqual(arr.dtype, arr_type, 'The array must be of type {0}'.format(arr_type))


### PR DESCRIPTION
This PR changes the type of all arrays which only contain {0,1-1} from int64 to int8.