### PR TITLE
Feature sim learn seeds

### DIFF
--- a/sim_learn.py
+++ b/sim_learn.py
@@ -4,6 +4,7 @@ PUF LTFarray simulation with the logistic regression learning algorithm. If you 
 define nine parameters which define the experiment.
 """
 import sys
+import argparse
 from pypuf.simulation.arbiter_based.ltfarray import LTFArray
 from pypuf.experiments.experiment.logistic_regression import ExperimentLogisticRegression
 from pypuf.experiments.experimenter import Experimenter
@@ -14,68 +15,72 @@ def main(args):
     This method includes the main functionality of the module it parses the argument vector and executes the learning
     attempts on the PUF instances.
     """
-    if len(args) < 10 or len(args) > 11:
-        sys.stderr.write('LTF Array Simulator and Logistic Regression Learner\n')
-        sys.stderr.write('Usage:\n')
-        sys.stderr.write('sim_learn.py n k transformation combiner N restarts seed_instance seed_model [log_name]\n')
-        sys.stderr.write('               n: number of bits per Arbiter chain\n')
-        sys.stderr.write('               k: number of Arbiter chains\n')
-        sys.stderr.write('  transformation: used to transform input before it is used in LTFs\n')
-        sys.stderr.write('                  currently available:\n')
-        sys.stderr.write('                  - id  -- does nothing at all\n')
-        sys.stderr.write('                  - atf -- convert according to "natural" Arbiter chain\n')
-        sys.stderr.write('                           implementation\n')
-        sys.stderr.write('                  - mm  -- designed to achieve maximum PTF expansion length\n')
-        sys.stderr.write('                           only implemented for k=2 and even n\n')
-        sys.stderr.write('                  - lightweight_secure -- design by Majzoobi et al. 2008\n')
-        sys.stderr.write('                                          only implemented for even n\n')
-        sys.stderr.write('                  - shift_lightweight_secure -- design like Majzoobi\n')
-        sys.stderr.write('                                                et al. 2008, but with the shift\n')
-        sys.stderr.write('                                                operation executed first\n')
-        sys.stderr.write('                                                only implemented for even n\n')
-        sys.stderr.write('                  - soelter_lightweight_secure -- design like Majzoobi\n')
-        sys.stderr.write('                                                  et al. 2008, but one bit different\n')
-        sys.stderr.write('                                                  only implemented for even n\n')
-        sys.stderr.write('                  - 1_n_bent -- one LTF gets "bent" input, the others id\n')
-        sys.stderr.write('                  - 1_1_bent -- one bit gets "bent" input, the others id,\n')
-        sys.stderr.write('                                this is proven to have maximum PTF\n')
-        sys.stderr.write('                                length for the model\n')
-        sys.stderr.write('                  - polynomial -- challenges are interpreted as polynomials\n')
-        sys.stderr.write('                                  from GF(2^64). From the initial challenge c,\n')
-        sys.stderr.write('                                  the i-th Arbiter chain gets the coefficients \n')
-        sys.stderr.write('                                  of the polynomial c^(i+1) as challenge.\n')
-        sys.stderr.write('                                  For now only challenges with length n=64 are accepted.\n')
-        sys.stderr.write(
-            '                  - permutation_atf -- for each Arbiter chain first a pseudorandom permutation \n')
-        sys.stderr.write('                                       is applied and thereafter the ATF transform.\n')
-        sys.stderr.write('                  - random -- Each Arbiter chain gets a random challenge derived from the\n')
-        sys.stderr.write('                              original challenge using a PRNG.\n')
-        sys.stderr.write('        combiner: used to combine the output bits to a single bit\n')
-        sys.stderr.write('                  currently available:\n')
-        sys.stderr.write('                  - xor     -- output the parity of all output bits\n')
-        sys.stderr.write('                  - ip_mod2 -- output the inner product mod 2 of all output\n')
-        sys.stderr.write('                               bits (even n only)\n')
-        sys.stderr.write('               N: number of challenge response pairs in the training set\n')
-        sys.stderr.write('        restarts: number of repeated initializations the learner\n')
-        sys.stderr.write('       instances: number of repeated initializations the instance\n')
-        sys.stderr.write('                  The number total learning attempts is restarts*instances.\n')
-        sys.stderr.write('   seed_instance: random seed used for LTF array instance\n')
-        sys.stderr.write('      seed_model: random seed used for the model in first learning attempt\n')
-        sys.stderr.write('      [log_name]: path to the logfile which contains results from all instances. The tool '
-                         'will add a ".log" to log_name. The default path is ./sim_learn.log\n')
-        quit(1)
+    parser = argparse.ArgumentParser(
+        prog='sim_learn',
+        description="LTF Array Simulator and Logistic Regression Learner",
+    )
+    parser.add_argument("n", help="number of bits per Arbiter chain", type=int)
+    parser.add_argument("k", help="number of Arbiter chains", type=int)
+    parser.add_argument(
+        "transformation",
+        help="used to transform input before it is used in LTFs. Currently available: "
+             '"atf,id",'
+             '"lightweight_secure",'
+             '"permutation_atf",'
+             '"polynomial,random",'
+             '"shift",'
+             '"soelter_lightweight_secure"',
+        type=str,
+    )
+    parser.add_argument(
+        'combiner',
+        help='used to combine the output bits to a single bit. Currently available: "ip_mod2", "xor"',
+        type=str,
+    )
+    parser.add_argument('N', help='number of challenge response pairs in the training set', type=int)
+    parser.add_argument('restarts', help='number of repeated initializations the learner', type=int)
+    parser.add_argument(
+        'instances',
+        help='number of repeated initializations the instance\n'
+             'The number total learning attempts is restarts*instances.',
+        type=int,
+    )
+    parser.add_argument('seed_instance', help='random seed used for LTF array instance', type=str)
+    parser.add_argument('seed_model', help='random seed used for the model in first learning attempt', type=str)
+    parser.add_argument(
+        '--log_name',
+        help='path to the logfile which contains results from all instances. The tool '
+             'will add a ".log" to log_name. The default path is ./sim_learn.log',
+        default='sim_learn',
+        type=str,
+    )
+    parser.add_argument(
+        '--seed_challenges',
+        help='random seed used to draw challenges for the training set',
+        type=str,
+    )
+    parser.add_argument('--seed_distance', help='random seed used to calculate the accuracy', type=str)
 
-    n = int(args[1])
-    k = int(args[2])
-    transformation_name = args[3]
-    combiner_name = args[4]
-    N = int(args[5])
-    restarts = int(args[6])
+    args = parser.parse_args(args)
 
-    instances = int(args[7])
+    n = args.n
+    k = args.k
+    transformation_name = args.transformation
+    combiner_name = args.combiner
+    N = args.N
+    restarts = args.restarts
 
-    seed_instance = int(args[8], 16)
-    seed_model = int(args[9], 16)
+    instances = args.instances
+
+    seed_instance = int(args.seed_instance, 16)
+    seed_model = int(args.seed_model, 16)
+
+    seed_challenges = 0x5A551
+    if args.seed_challenges is not None:
+        seed_challenges = int(args.seed_challenges, 16)
+    seed_distance = 0xB055
+    if args.seed_distance is not None:
+        seed_distance = int(args.seed_distance, 16)
 
     transformation = None
     combiner = None
@@ -92,9 +97,7 @@ def main(args):
         sys.stderr.write('Combiner %s unknown or currently not implemented\n' % combiner_name)
         quit()
 
-    log_name = 'sim_learn'
-    if len(args) == 11:
-        log_name = args[10]
+    log_name = args.log_name
 
     sys.stderr.write('Learning %s-bit %s XOR Arbiter PUF with %s CRPs and %s restarts.\n\n' % (n, k, N, restarts))
     sys.stderr.write('Using\n')
@@ -117,7 +120,9 @@ def main(args):
                 seed_instance=seed_instance + j,
                 seed_model=seed_model + j + start_number,
                 transformation=transformation,
-                combiner=combiner
+                combiner=combiner,
+                seed_challenge=seed_challenges,
+                seed_chl_distance=seed_distance,
             )
             experiments.append(experiment)
 
@@ -146,4 +151,4 @@ def main(args):
 
 
 if __name__ == '__main__':
-    main(sys.argv)
+    main(sys.argv[1:])

--- a/test/test_sim_learn.py
+++ b/test/test_sim_learn.py
@@ -36,11 +36,6 @@ class TestSimLearn(unittest.TestCase):
         sim_learn.main(["8", "2", "atf", "xor", "20", "1", "2", "1234", "1234", self.log_parameter("test_atf")])
 
     @mute
-    def test_mm(self):
-        """This tests the mm transformation and xor combiner."""
-        sim_learn.main(["8", "2", "mm", "xor", "20", "1", "2", "1234", "1234", self.log_parameter("test_mm")])
-
-    @mute
     def test_lightweight_secure(self):
         """This tests the lightweight secure transformation and xor combiner."""
         sim_learn.main(["8", "2", "lightweight_secure", "xor", "20", "1", "2", "1234", "1234",

--- a/test/test_sim_learn.py
+++ b/test/test_sim_learn.py
@@ -8,6 +8,7 @@ class TestSimLearn(unittest.TestCase):
     """
     This class is used to test different parameters for the sim_learn module.
     """
+
     def setUp(self):
         # Remove all log files
         remove_test_logs()
@@ -19,41 +20,41 @@ class TestSimLearn(unittest.TestCase):
     @mute
     def test_id(self):
         """This tests the id transformation and xor combiner."""
-        sim_learn.main(["sim_learn", "8", "2", "id", "xor", "20", "1", "2", "1234", "1234", LOG_PATH + "test_id"])
+        sim_learn.main(["8", "2", "id", "xor", "20", "1", "2", "1234", "1234", LOG_PATH + "test_id"])
 
     @mute
     def test_atf(self):
         """This tests the atf transformation and xor combiner."""
-        sim_learn.main(["sim_learn", "8", "2", "atf", "xor", "20", "1", "2", "1234", "1234", LOG_PATH + "test_atf"])
+        sim_learn.main(["8", "2", "atf", "xor", "20", "1", "2", "1234", "1234", LOG_PATH + "test_atf"])
 
     @mute
     def test_lightweight_secure(self):
-        """This tests the lightweight secure original transformation and xor combiner."""
-        sim_learn.main(["sim_learn", "8", "2", "lightweight_secure", "xor", "20", "1", "2", "1234", "1234",
-                        LOG_PATH+"test_lightweight_secure_original"])
+        """This tests the lightweight secure transformation and xor combiner."""
+        sim_learn.main(["8", "2", "lightweight_secure", "xor", "20", "1", "2", "1234", "1234",
+                        LOG_PATH+"test_lightweight_secure"])
 
     @mute
     def test_ip_mod2_id(self):
         """This tests the identity transformation and inner product mod 2 combiner."""
-        sim_learn.main(["sim_learn", "8", "2", "id", "ip_mod2", "20", "1", "2", "1234", "1234",
+        sim_learn.main(["8", "2", "id", "ip_mod2", "20", "1", "2", "1234", "1234",
                         LOG_PATH + "test_ip_mod2_id"])
 
     @mute
     def test_ip_mod2_atf(self):
         """This tests the atf transformation and inner product mod 2 combiner."""
-        sim_learn.main(["sim_learn", "8", "2", "atf", "ip_mod2", "20", "1", "2", "1234", "1234",
+        sim_learn.main(["8", "2", "atf", "ip_mod2", "20", "1", "2", "1234", "1234",
                         LOG_PATH + "test_ip_mod2_atf"])
 
     @mute
     def test_ip_mod2_lightweight_secure(self):
         """This tests the lightweight secure transformation and inner product mod 2 combiner."""
-        sim_learn.main(["sim_learn", "8", "2", "lightweight_secure", "ip_mod2", "20", "1", "2", "1234", "1234",
+        sim_learn.main(["8", "2", "lightweight_secure", "ip_mod2", "20", "1", "2", "1234", "1234",
                         LOG_PATH + "test_ip_mod2_lightweight_secure"])
 
     @mute
     def test_permutation_atf(self):
         """This tests the atf permutation transformation and xor combiner."""
-        sim_learn.main(["sim_learn", "8", "2", "permutation_atf", "xor", "10", "1", "2", "1234", "1234",
+        sim_learn.main(["8", "2", "permutation_atf", "xor", "10", "1", "2", "1234", "1234",
                         LOG_PATH + "test_permutation_atf"])
 
     @mute
@@ -61,7 +62,7 @@ class TestSimLearn(unittest.TestCase):
         """This tests for the expected number of lines in the main log file."""
         instance_count = 2
         log_name = LOG_PATH + 'test_log_name'
-        sim_learn.main(["sim_learn", "8", "2", "id", "xor", "10", "1", str(instance_count), "1234", "1234", log_name])
+        sim_learn.main(["8", "2", "id", "xor", "10", "1", str(instance_count), "1234", "1234", log_name])
 
         def line_count(file_object):
             """
@@ -88,7 +89,8 @@ class TestSimLearn(unittest.TestCase):
         expected_number_of_result = instance_count * restarts
         log_name = LOG_PATH + 'test_number_of_results'
         sim_learn.main(
-            ["sim_learn", "8", "2", "id", "xor", "10", str(restarts), str(instance_count), "1234", "1234", log_name]
+            ["8", "2", "id", "xor", "10", str(restarts), str(instance_count), "1234", "1234",
+             '--log_name={0}'.format(log_name)]
         )
 
         def line_count(file_object):
@@ -105,3 +107,10 @@ class TestSimLearn(unittest.TestCase):
         log_file = open(log_name + '.log', 'r')
         self.assertEqual(line_count(log_file), expected_number_of_result, 'Unexpected number of results')
         log_file.close()
+
+    def test_seed_challenges(self):
+        """This test the trainingset challenge generation to be deterministic with different seeds."""
+        log_name = 'test/test_log'
+        log_parameter = '--log_name={0}'.format(log_name)
+        seed_parameter = '--seed_challenges=0xBA11'
+        sim_learn.main(["8", "2", "id", "xor", "20", "1", "2", "1234", "1234", log_parameter, seed_parameter])

--- a/test/test_sim_learn.py
+++ b/test/test_sim_learn.py
@@ -17,80 +17,66 @@ class TestSimLearn(unittest.TestCase):
         # Remove all log files
         remove_test_logs()
 
+    def log_parameter(self, name):
+        """
+        This function returns a the log parameter compatible with sim_learn.
+        :param name: string
+                     name of the logfile
+        """
+        return '--log_name={0}'.format(LOG_PATH + name)
+
     @mute
     def test_id(self):
         """This tests the id transformation and xor combiner."""
-        sim_learn.main(["8", "2", "id", "xor", "20", "1", "2", "1234", "1234", LOG_PATH + "test_id"])
+        sim_learn.main(["8", "2", "id", "xor", "20", "1", "2", "1234", "1234", self.log_parameter("test_id")])
 
     @mute
     def test_atf(self):
         """This tests the atf transformation and xor combiner."""
-        sim_learn.main(["8", "2", "atf", "xor", "20", "1", "2", "1234", "1234", LOG_PATH + "test_atf"])
+        sim_learn.main(["8", "2", "atf", "xor", "20", "1", "2", "1234", "1234", self.log_parameter("test_atf")])
+
+    @mute
+    def test_mm(self):
+        """This tests the mm transformation and xor combiner."""
+        sim_learn.main(["8", "2", "mm", "xor", "20", "1", "2", "1234", "1234", self.log_parameter("test_mm")])
 
     @mute
     def test_lightweight_secure(self):
         """This tests the lightweight secure transformation and xor combiner."""
         sim_learn.main(["8", "2", "lightweight_secure", "xor", "20", "1", "2", "1234", "1234",
-                        LOG_PATH+"test_lightweight_secure"])
+                        self.log_parameter("test_lightweight_secure")])
 
     @mute
     def test_ip_mod2_id(self):
         """This tests the identity transformation and inner product mod 2 combiner."""
-        sim_learn.main(["8", "2", "id", "ip_mod2", "20", "1", "2", "1234", "1234",
-                        LOG_PATH + "test_ip_mod2_id"])
+        sim_learn.main(
+            ["8", "2", "id", "ip_mod2", "20", "1", "2", "1234", "1234", self.log_parameter("test_ip_mod2_id")])
 
     @mute
     def test_ip_mod2_atf(self):
         """This tests the atf transformation and inner product mod 2 combiner."""
-        sim_learn.main(["8", "2", "atf", "ip_mod2", "20", "1", "2", "1234", "1234",
-                        LOG_PATH + "test_ip_mod2_atf"])
+        sim_learn.main(
+            ["8", "2", "atf", "ip_mod2", "20", "1", "2", "1234", "1234", self.log_parameter("test_ip_mod2_atf")])
 
     @mute
     def test_ip_mod2_lightweight_secure(self):
         """This tests the lightweight secure transformation and inner product mod 2 combiner."""
         sim_learn.main(["8", "2", "lightweight_secure", "ip_mod2", "20", "1", "2", "1234", "1234",
-                        LOG_PATH + "test_ip_mod2_lightweight_secure"])
+                        self.log_parameter("test_ip_mod2_lightweight_secure")])
 
     @mute
     def test_permutation_atf(self):
         """This tests the atf permutation transformation and xor combiner."""
         sim_learn.main(["8", "2", "permutation_atf", "xor", "10", "1", "2", "1234", "1234",
-                        LOG_PATH + "test_permutation_atf"])
+                        self.log_parameter("test_permutation_atf")])
 
     @mute
     def test_log_name(self):
         """This tests for the expected number of lines in the main log file."""
         instance_count = 2
-        log_name = LOG_PATH + 'test_log_name'
-        sim_learn.main(["8", "2", "id", "xor", "10", "1", str(instance_count), "1234", "1234", log_name])
-
-        def line_count(file_object):
-            """
-            :param file_object:
-            :return: number of lines
-            """
-            count = 0
-            while file_object.readline() != '':
-                count = count + 1
-            return count
-
-        # Check if the number of results is correct
-        log_file = open(log_name + '.log', 'r')
-        self.assertEqual(line_count(log_file), instance_count, 'Unexpected number of results')
-        log_file.close()
-
-    @mute
-    def test_number_of_results(self):
-        """
-        This test checks the number of results to match a previous calculated value.
-        """
-        instance_count = 7
-        restarts = 13
-        expected_number_of_result = instance_count * restarts
-        log_name = LOG_PATH + 'test_number_of_results'
+        log_name = "test_log_name"
         sim_learn.main(
-            ["8", "2", "id", "xor", "10", str(restarts), str(instance_count), "1234", "1234",
-             '--log_name={0}'.format(log_name)]
+            ["8", "2", "id", "xor", "10", "1", str(instance_count), "1234", "1234", self.log_parameter(log_name)]
         )
 
         def line_count(file_object):
@@ -104,13 +90,97 @@ class TestSimLearn(unittest.TestCase):
             return count
 
         # Check if the number of results is correct
-        log_file = open(log_name + '.log', 'r')
+        log_file = open(LOG_PATH + log_name + '.log', 'r')
+        self.assertEqual(line_count(log_file), instance_count, 'Unexpected number of results')
+        log_file.close()
+
+    @mute
+    def test_number_of_results(self):
+        """
+        This test checks the number of results to match a previous calculated value.
+        """
+        instance_count = 7
+        restarts = 13
+        expected_number_of_result = instance_count * restarts
+        log_name = 'test_number_of_results'
+        sim_learn.main(
+            ["8", "2", "id", "xor", "10", str(restarts), str(instance_count), "1234", "1234",
+             self.log_parameter(log_name)]
+        )
+
+        def line_count(file_object):
+            """
+            :param file_object:
+            :return: number of lines
+            """
+            count = 0
+            while file_object.readline() != '':
+                count = count + 1
+            return count
+
+        # Check if the number of results is correct
+        log_file = open(LOG_PATH + log_name + '.log', 'r')
         self.assertEqual(line_count(log_file), expected_number_of_result, 'Unexpected number of results')
         log_file.close()
 
-    def test_seed_challenges(self):
-        """This test the trainingset challenge generation to be deterministic with different seeds."""
-        log_name = 'test/test_log'
-        log_parameter = '--log_name={0}'.format(log_name)
-        seed_parameter = '--seed_challenges=0xBA11'
-        sim_learn.main(["8", "2", "id", "xor", "20", "1", "2", "1234", "1234", log_parameter, seed_parameter])
+    def read_log(self, path):
+        """This function reads the content of a log file without time measuring and deletes the file.
+        :param path: string
+                     Path to a file
+        :return: list of list of string
+        """
+        lines = []
+        with open(path, 'r') as file:
+            line = file.readline()
+            while line != '':
+                values = line.split('\t')
+                # Drop the time value
+                del values[9]
+                lines.append(values)
+                line = file.readline()
+        remove_test_logs(path)
+        return lines
+
+    def check_seeds(self, parameter_set1, parameter_set2, log_path):
+        """
+        This method checks the results of sim_learn for different parameter lists.
+        :param parameter_set1: list of string
+        :param parameter_set2: list of string
+        :param log_path: string
+        """
+        sim_learn.main(parameter_set1)
+        res_param_set1 = self.read_log(log_path)
+
+        sim_learn.main(parameter_set2)
+        res_param_set2 = self.read_log(log_path)
+
+        # Test challenge seed impact
+        self.assertNotEqual(res_param_set1, res_param_set2)
+
+        sim_learn.main(parameter_set1)
+        res_param_set1_2 = self.read_log(log_path)
+
+        sim_learn.main(parameter_set2)
+        res_param_set2_2 = self.read_log(log_path)
+
+        # Test challenge to be deterministic
+        self.assertEqual(res_param_set2, res_param_set2_2)
+        self.assertEqual(res_param_set1, res_param_set1_2)
+
+    @mute
+    def test_seeds(self):
+        """
+        This test the trainingset challenge generation and accuracy seeds.
+        Whit this seeds sim_learn should be deterministic.
+        """
+        log_name = 'test_seed_challenges'
+        log_path = LOG_PATH + log_name + '.log'
+        parameter = ["8", "2", "id", "xor", "20", "1", "2", "1234", "1234", self.log_parameter(log_name)]
+        seed_parameter_chl = '--seed_challenges=0xBA11'
+        seed_parameter_dist = '--seed_distance=5ACE'
+        parameter_with_seed_chl = parameter + [seed_parameter_chl]
+        parameter_with_seed_dist = parameter + [seed_parameter_dist]
+
+        self.check_seeds(parameter, parameter_with_seed_chl, log_path)
+        self.check_seeds(parameter, parameter_with_seed_dist, log_path)
+        self.check_seeds(parameter_with_seed_chl, parameter_with_seed_dist, log_path)


### PR DESCRIPTION
This PR reworks the parameter interface of sim_learn.py. I introduced two optional parameters `--seed_challenges` and `--seed_distance`. The new parameter can be used to set the challenge seed (`seed_challenges`) or accuracy challenges seed (`seed_distance`). This PR is blocked by #99 and #98 and I will resume enhancing this until they get reviewed and merged.