### PR TITLE
fix memory leak

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ numpy==1.13.*
 pep8==1.7.*
 polymath==0.1.17
 pylint==1.7.*
-pypuf-helper==0.1.2.*
+pypuf-helper==0.1.4
 scipy==0.19.*


### PR DESCRIPTION
The PR #101 introduced a wrong version of `pypuf-helper` again which causes a memory leak.
Please merge it.