### PR TITLE
Add Linter File Exclusion

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -54,7 +54,8 @@ def main(arguments):
             continue
 
         for filename in fn_filter(file_names, '*.py'):
-            files_to_check.append(path.join(root, filename))
+            if not reduce((lambda x, y: x or y), [pattern in filename for pattern in args.exclude_patterns]):
+                files_to_check.append(path.join(root, filename))
 
     # if the path is a single file
     if not files_to_check:


### PR DESCRIPTION
From time to time I use a temporary file to debug some code where code style is a minor point. If I run the linter after applying the bug fixes in the repository code, I usually get linter error messages from my messy debug file. I do not want to delete the file after debugging stuff. To enhance the linter, I added the possibility to exclude specific files to be checked by pylint. There is no need to adjust the pep8 parameter passing because it worked out of the box.