### PR TITLE
Experimenter Status Display

### DIFF
--- a/pypuf/experiments/experiment/base.py
+++ b/pypuf/experiments/experiment/base.py
@@ -6,6 +6,7 @@ import abc
 import time
 import logging
 import logging.handlers
+from pypuf.experiments.experimenter import Experimenter
 
 
 class Experiment(object):
@@ -62,6 +63,7 @@ class Experiment(object):
         self.run()
         self.measured_time = time.time() - start_time
         self.analyze()
+        self.result_logger.info(Experimenter.PRINT_DELIMITER + '{}'.format(self.measured_time))
 
 
 def setup_result_logger(queue, logger_name):

--- a/pypuf/experiments/experimenter.py
+++ b/pypuf/experiments/experimenter.py
@@ -20,6 +20,8 @@ import multiprocessing
 import logging
 import sys
 import traceback
+import time
+from numpy import mean
 
 
 class Experimenter(object):
@@ -27,9 +29,13 @@ class Experimenter(object):
     Coordinated, parallel execution of Experiments with logging.
     """
 
-    def __init__(self, log_name, experiments, cpu_limit=2**16):
+    PRINT_DELIMITER = 'PRINT:'
+
+    def __init__(self, log_name, experiments, status_display=False, cpu_limit=2**16):
         """
         :param experiments: A list of pypuf.experiments.experiment.base.Experiment
+        :param status_display: boolean
+                               This value determines to display status information about the experiment execution.
         :param log_name: A unique file path where to output should be logged.
         :param cpu_limit: Maximum number of parallel processes that run experiments.
         """
@@ -43,6 +49,7 @@ class Experimenter(object):
         # Setup parallel execution limit
         self.cpu_limit = min(cpu_limit, multiprocessing.cpu_count())
         self.semaphore = multiprocessing.BoundedSemaphore(self.cpu_limit)
+        self.status_display = status_display
 
     def run(self):
         """
@@ -51,8 +58,10 @@ class Experimenter(object):
 
         # Setup multiprocessing logging
         queue = multiprocessing.Queue(-1)
-        listener = multiprocessing.Process(target=log_listener,
-                                           args=(queue, setup_logger, self.logger_name,))
+        listener = multiprocessing.Process(
+            target=log_listener,
+            args=(queue, setup_logger, self.logger_name, len(self.experiments), self.status_display,)
+        )
         listener.start()
 
         # list of active jobs
@@ -131,7 +140,7 @@ def setup_logger(logger_name):
     root.addHandler(file_handler)
 
 
-def log_listener(queue, configurer, logger_name):
+def log_listener(queue, configurer, logger_name, max_exp=1, status_display=False):
     """
     This is the root function of logging process which is responsible to log the experiment results.
     :param queue: multiprocessing.queue
@@ -139,15 +148,72 @@ def log_listener(queue, configurer, logger_name):
     :param configurer: A function which setup the logger which logs the messages read from the queue.
     :param logger_name: String
                         Path to or name to the log file
+    :param max_exp: int default is 0
+                    Number of experiments to execute.
+    :param status_display: boolean
+                           This value determines to display status information about the experiment execution.
     """
     configurer(logger_name)
+    experiments_done = 0
+    times = []
+    runtime = 0.0
+    if status_display:
+        # Print status header
+        header = '\rFinished Experiments|Average Execution Time|Estimated Runtime|Runtime\n'
+        sys.stderr.write(header)
+        sys.stderr.flush()
     while True:
+        if status_display:
+            time.sleep(1)
+            # Approximate the runtime of the experimenter
+            runtime += 1
+            # Refresh the status display
+            print_status(times, experiments_done, max_exp, runtime)
         try:
-            record = queue.get()
+            if queue.empty():
+                continue
+            if status_display:
+                record = queue.get_nowait()
+            else:
+                record = queue.get()
             if record is None:  # We send this as a sentinel to tell the listener to quit.
                 break
-            logger = logging.getLogger(record.name)
-            logger.handle(record)  # No level or filter logic applied - just do it!
+
+            # Recognize experiments end and get the execution time
+            if record.msg.startswith(Experimenter.PRINT_DELIMITER):
+                times.append(float(record.msg.replace(Experimenter.PRINT_DELIMITER, '')))
+                runtime += times[-1]
+                experiments_done += 1
+                continue
+            else:
+                # Log the result into a file
+                logger = logging.getLogger(record.name)
+                logger.handle(record)  # No level or filter logic applied - just do it!
         except Exception:  # pylint: disable=W
             print('Whoops! Problem:', file=sys.stderr)
             traceback.print_exc(file=sys.stderr)
+
+
+def print_status(times, experiments_done, max_experiments, runtime):
+    """
+    This function can be used to display information about the experimenter runtime.
+    :param times: list of float
+                  List of experiment execution times
+    :param experiments_done: int
+                             Number fo finished experiments.
+    :param max_experiments: int
+                            Number of experiments to execute
+    :param runtime: float
+                    Time the experimenter runs.
+    """
+    if times == []:
+        sys.stderr.write('\rwait for finished experiments...')
+        sys.stderr.flush()
+        return
+
+    mean_exe_time = round(mean(times), 2)
+    estimated_runtime = round(mean_exe_time * max_experiments, 2)
+    exp_overview = '{}/{}'.format(experiments_done, max_experiments)
+    values = '\r{:<20}|{:<22}|{:<17}|{:<9}'.format(exp_overview, mean_exe_time, estimated_runtime, round(runtime, 2))
+    sys.stderr.write(values)
+    sys.stderr.flush()


### PR DESCRIPTION
After creating some bigger experiment list for property testing, I realized that it is beneficial to know how long the experiments run. For that purpose is introduce a status display option to the Experimenter. Let's have a look at some example output
```
Finished Experiments|Average Execution Time|Estimated Runtime|Runtime
wait for finished experiments...
```
After passing the first experiment, the logging process displays some information about the experimenter run. 
```
Finished Experiments|Average Execution Time|Estimated Runtime|Runtime
9/24                |6.33                  |151.92           |79.00
```
The estimated runtime is the product of average execution time and the absolute number of experiments to calculate. As an effect of multiprocessing is that the estimated runtime is much bigger than the actual runtime. I did not know how to approximate the real runtime with a minor error for inhomogenous experiment runtimes. However, this status display was not invented to be super accurate. The number of passed experiments is much more important than the estimated runtime.
  