### PR TITLE
Fix Typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ from pypuf.learner.regression.logistic_regression import LogisticRegression
 from pypuf.simulation.arbiter_based.ltfarray import LTFArray
 
 # create a simulation with random (Gaussian) weights
-# for 64-bit 4-XOR 
+# for 64-bit 2-XOR
 instance = LTFArray(
     weight_array=LTFArray.normal_weights(n=64, k=2),
     transform=LTFArray.transform_atf,

--- a/example.py
+++ b/example.py
@@ -13,7 +13,7 @@ def main():
     """
 
     # create a simulation with random (Gaussian) weights
-    # for 64-bit 4-XOR
+    # for 64-bit 2-XOR
     instance = LTFArray(
         weight_array=LTFArray.normal_weights(n=64, k=2),
         transform=LTFArray.transform_atf,


### PR DESCRIPTION
This fixes typos reported in #115.

@songhuadan88 reported
"README.md line 105
example.py line 16
I think "4-XOR" should be "2-XOR".
Typos or I am thinking in the wrong way?"