### PR TITLE
auto-update compatibility versions on the third level

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-numpy~=1.16
-pycodestyle~=2.4
+numpy~=1.16.0
+pycodestyle~=2.4.0
 polymath==0.1.18
-pylint~=2.2
-scipy~=1.2
-astroid~=2.1
-matplotlib~=3.0
+pylint~=2.2.0
+scipy~=1.2.0
+astroid~=2.1.0
+matplotlib~=3.0.0


### PR DESCRIPTION
~=V.N means >= V.N and V.*, so if we want to automatically
install, say, 1.14.4, but not 1.15.0, then we need to say
~=1.14.4 and not ~=1.14.