### PR TITLE
Added GPU Management

### DIFF
--- a/pypuf/experiments/experiment/base.py
+++ b/pypuf/experiments/experiment/base.py
@@ -43,6 +43,9 @@ class Experiment(object):
         self.hash = sha256((self.__class__.__name__ + ': ' + str(parameters)).encode()).hexdigest()
         self.result = None
 
+        # GPU is unset. Experimenter uses assign_to_gpu() before executing experiment
+        self.gpu_id = None
+
         # This must be set at run, loggers can (under circumstances) not be pickled
         self.progress_logger = None
         self.result_logger = None
@@ -71,6 +74,12 @@ class Experiment(object):
         This method runs the actual experiment.
         """
         raise NotImplementedError('users must define run() to use this base class')
+
+    def assign_to_gpu(self, gpu_id):
+        """
+            Set gpu_id. Called by Experimenter to load-balance GPUs
+        """
+        self.gpu_id = gpu_id
 
     def execute(self, result_log_queue, result_log_name, cancel_experiment=None, interrupt_condition=None):
         """

--- a/pypuf/studies/base.py
+++ b/pypuf/studies/base.py
@@ -30,7 +30,7 @@ class Study:
     COMPRESSION = False
     STUDY_MODULE_PREFIX = 'pypuf.studies.'
 
-    def __init__(self, cpu_limit=None):
+    def __init__(self, cpu_limit=None, gpu_limit=None):
         """
         Initialize the study.
         """
@@ -46,6 +46,7 @@ class Study:
             update_callback=callback,
             update_callback_min_pause=self.EXPERIMENTER_CALLBACK_MIN_PAUSE,
             cpu_limit=cpu_limit,
+            gpu_limit=gpu_limit,
             results_file=self.name() + ('.csv.gz' if self.COMPRESSION else '.csv'),
         )
 


### PR DESCRIPTION
Studies can set number of GPU available for an experimenter.
Experimenter is able to assign gpu_ids to experiments.
Experiments have a member variable gpu_id, indicating on which GPU the experimnent shall be executed.