### PR TITLE
Adjust Weight Distribution and Bias von XOR Arbiter PUFs

### DIFF
--- a/docs/attacks/lr.rst
+++ b/docs/attacks/lr.rst
@@ -26,7 +26,7 @@ need careful adjustment for each choice of security parameters in the PUF. Then 
 >>> attack.fit()  # doctest:+ELLIPSIS +NORMALIZE_WHITESPACE
     Epoch 1/100
     ...
-    50/50 [==============================] - ... - loss: 0.4... - accuracy: 0.9... - val_loss: 0.4556 - val_accuracy: 0.9600
+    50/50 [==============================] - ... - loss: 0.4... - accuracy: 0.9... - val_loss: 0.4643 - val_accuracy: 0.9620
     <pypuf.simulation.base.LTFArray object at 0x...>
 >>> model = attack.model
 
@@ -34,7 +34,7 @@ The model accuracy can be measured using the pypuf accuracy metric :meth:`pypuf.
 
 >>> import pypuf.metrics
 >>> pypuf.metrics.similarity(puf, model, seed=4)
-array([0.957])
+array([0.966])
 
 Applicability
 -------------

--- a/docs/attacks/mlp.rst
+++ b/docs/attacks/mlp.rst
@@ -31,7 +31,7 @@ need careful adjustment for each choice of security parameters in the PUF. Then 
 >>> attack.fit()  # doctest:+ELLIPSIS +NORMALIZE_WHITESPACE
     Epoch 1/30
     ...
-    495/495 [==============================] - ... - loss: 0.0... - accuracy: 0.9... - val_loss: 0.0658 - val_accuracy: 0.9730
+    495/495 [==============================] - ... - loss: 0.0... - accuracy: 0.9... - val_loss: 0.0670 - val_accuracy: 0.9750
     <pypuf.attack.mlp2021.MLPAttack2021.Model object at 0x...>
 >>> model = attack.model
 
@@ -39,7 +39,7 @@ The model accuracy can be measured using the pypuf accuracy metric :meth:`pypuf.
 
 >>> import pypuf.metrics
 >>> pypuf.metrics.similarity(puf, model, seed=4)
-array([0.963])
+array([0.97])
 
 Example Usage [AZA18]_
 ----------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -73,7 +73,7 @@ Then generate a list of `N` random challenges of length 64 (again with a seed fo
 Finally, evaluate the XOR Arbiter PUF on these challenges, it will yield 10 responses.
 
 >>> puf.eval(challenges)
-array([-1, -1, -1,  1,  1, -1,  1, -1,  1, -1], dtype=int8)
+array([-1, -1,  1,  1,  1,  1,  1,  1, -1, -1], dtype=int8)
 
 For a more detailed information on simulation of PUFs, continue with
 :doc:`the section on simulations <simulation/overview>`.

--- a/docs/simulation/arbiter_puf.rst
+++ b/docs/simulation/arbiter_puf.rst
@@ -28,7 +28,7 @@ For example, to evaluate an Arbiter PUF on three randomly chosen challenges:
 >>> puf = ArbiterPUF(n=64, seed=1)
 >>> from pypuf.io import random_inputs
 >>> puf.eval(random_inputs(n=64, N=3, seed=2))
-array([-1,  1, -1], dtype=int8)
+array([ 1,  1, -1], dtype=int8)
 
 For noisy simulations, a noise level needs to be given. Basically, the higher the number, the more likely responses
 are to be disturbed by noise; however the influence of noise also depends on the challenge given and the concrete
@@ -65,7 +65,7 @@ To simulate an 8-XOR 64-bit XOR Arbiter PUF using relatively stable Arbiter PUF 
 >>> puf = XORArbiterPUF(n=64, k=8, seed=1, noisiness=.05)
 >>> from pypuf.io import random_inputs
 >>> puf.eval(random_inputs(n=64, N=3, seed=2))
-array([-1,  1, -1], dtype=int8)
+array([-1, -1,  1], dtype=int8)
 
 .. note::
     The `noisiness` parameter in the XOR Arbiter PUF is directly referring to the noise of `each` Arbiter PUF in the
@@ -114,7 +114,7 @@ To simulate an 8-XOR 64-bit XOR Arbiter PUF using relatively stable Arbiter PUF 
 >>> puf = LightweightSecurePUF(n=64, k=8, seed=1, noisiness=.05)
 >>> from pypuf.io import random_inputs
 >>> puf.eval(random_inputs(n=64, N=3, seed=2))
-array([ 1, -1, -1], dtype=int8)
+array([-1, -1, -1], dtype=int8)
 
 
 Permutation PUF
@@ -136,7 +136,7 @@ To simulate an 8-XOR 64-bit XOR Arbiter PUF using relatively stable Arbiter PUF 
 >>> puf = PermutationPUF(n=64, k=8, seed=1, noisiness=.05)
 >>> from pypuf.io import random_inputs
 >>> puf.eval(random_inputs(n=64, N=3, seed=2))
-array([-1, -1, -1], dtype=int8)
+array([ 1, -1,  1], dtype=int8)
 
 
 Interpose PUF
@@ -161,6 +161,6 @@ To simulate an (8,8) 64-bit Interpose PUF using relatively stable Arbiter PUF im
 >>> puf = InterposePUF(n=64, k_up=8, k_down=8, seed=1, noisiness=.05)
 >>> from pypuf.io import random_inputs
 >>> puf.eval(random_inputs(n=64, N=3, seed=2))
-array([ 1, -1, -1], dtype=int8)
+array([-1,  1, -1], dtype=int8)
 
 Note that the ``noisiness`` parameter applies to both upper and lower layer.

--- a/pypuf/attack/lr2021.py
+++ b/pypuf/attack/lr2021.py
@@ -115,17 +115,25 @@ class LRAttack2021(OfflineAttack):
         # crps.responses[crps.responses == -1] = 1
 
         input_tensor = tf.keras.Input(shape=(n,))
-        prod = tf.keras.layers.Multiply()(
-            [
-                tf.keras.layers.Dense(
-                    units=1,
-                    kernel_initializer=tf.keras.initializers.RandomNormal(),
-                    bias_initializer=tf.keras.initializers.Zeros(),
-                    activation=tf.keras.activations.tanh,
-                )(input_tensor) for _ in range(k)
-            ]
-        )
-        output = tf.keras.layers.Activation('tanh')(prod)
+        if self.k > 1:
+            prod = tf.keras.layers.Multiply()(
+                [
+                    tf.keras.layers.Dense(
+                        units=1,
+                        kernel_initializer=tf.keras.initializers.RandomNormal(),
+                        bias_initializer=tf.keras.initializers.Zeros(),
+                        activation=tf.keras.activations.tanh,
+                    )(input_tensor) for _ in range(k)
+                ]
+            )
+            output = tf.keras.layers.Activation('tanh')(prod)
+        else:
+            output = tf.keras.layers.Dense(
+                units=1,
+                kernel_initializer=tf.keras.initializers.RandomNormal(),
+                bias_initializer=tf.keras.initializers.Zeros(),
+                activation=tf.keras.activations.tanh,
+            )(input_tensor)
 
         model = tf.keras.Model(inputs=[input_tensor], outputs=[output])
         model.compile(

--- a/pypuf/metrics/common.py
+++ b/pypuf/metrics/common.py
@@ -69,18 +69,18 @@ def reliability(instance: Simulation, seed: int, N: int = 10000, r: int = 17) ->
     >>> from numpy import average
     >>> puf = XORArbiterPUF(n=128, k=2, seed=1, noisiness=.2)
     >>> average(reliability(puf, seed=2), axis=0)
-    array([0.84887197])
+    array([0.84967612])
 
     An example of an extremely noisy PUF:
 
     >>> average(reliability(XORArbiterPUF(n=32, k=12, seed=1, noisiness=1), seed=2), axis=0)
-    array([0.52879308])
+    array([0.52975917])
 
 
     An example of a very reliable PUF:
 
     >>> average(reliability(ArbiterPUF(n=32, seed=1, noisiness=.01), seed=2), axis=0)
-    array([0.99576886])
+    array([0.99582561])
 
     An example of a perfectly reliable PUF:
 
@@ -163,7 +163,7 @@ def uniqueness(instances: List[Simulation], seed: int, N: int = 10000) -> np.nda
     >>> from pypuf.metrics import uniqueness
     >>> instances = [XORArbiterPUF(n=64, k=1, seed=seed) for seed in range(5)]
     >>> uniqueness(instances, seed=31415, N=1000)
-    array([0.9272])
+    array([0.924])
     """
     m = instances[0].response_length
     challenges = random_inputs(instances[0].challenge_length, N, seed)
@@ -232,11 +232,11 @@ def accuracy(simulation: Simulation, test_set: ChallengeResponseSet) -> np.ndarr
     >>> puf = XORArbiterPUF(n=128, k=4, noisiness=.1, seed=1)
     >>> test_set = ChallengeResponseSet.from_simulation(puf, N=1000, seed=2)
     >>> accuracy(puf, test_set)
-    array([0.823])
+    array([0.843])
     >>> puf = XORArbiterPUF(n=64, k=4, noisiness=.3, seed=2)
     >>> test_set = ChallengeResponseSet.from_simulation(puf, N=1000, seed=2, r=5)
     >>> accuracy(puf, test_set)
-    array([0.706])
+    array([0.69])
     """
     sim_responses = simulation.eval(test_set.challenges)
     return similarity_data(sim_responses, test_set.responses)
@@ -262,7 +262,7 @@ def similarity(instance1: Simulation, instance2: Simulation, seed: int, N: int =
     >>> similarity(XORArbiterPUF(n=128, k=4, seed=1), XORArbiterPUF(n=128, k=4, seed=1), seed=31415)  # same seed
     array([1.])
     >>> similarity(XORArbiterPUF(n=128, k=4, seed=1), XORArbiterPUF(n=128, k=4, seed=2), seed=31415)  # different seed
-    array([0.515])
+    array([0.516])
     """
     if instance1.challenge_length != instance2.challenge_length:
         raise ValueError(f'Cannot compare instances with different challenge spaces of dimension '
@@ -303,13 +303,13 @@ def bias(instance: Simulation, seed: int, N: int = 1000) -> np.ndarray:
     >>> from pypuf.simulation import ArbiterPUF
     >>> from pypuf.metrics import bias
     >>> bias(ArbiterPUF(n=128, seed=42), seed=1)
-    0.022
+    -0.004
 
     On the other hand, 2-XOR Arbiter PUFs can have relatively large bias [WP20]_.
 
     >>> from pypuf.simulation import XORArbiterPUF
     >>> bias(XORArbiterPUF(n=64, k=2, seed=2), seed=2)
-    -0.05
+    -0.086
     """
     challenges = random_inputs(n=instance.challenge_length, N=N, seed=seed)
     return bias_data(instance.eval(challenges))

--- a/pypuf/simulation/base.py
+++ b/pypuf/simulation/base.py
@@ -47,19 +47,19 @@ class Simulation:
         >>> from pypuf.simulation import XORArbiterPUF
         >>> from pypuf.io import random_inputs
         >>> puf = XORArbiterPUF(n=64, k=4, noisiness=.02, seed=1)
-        >>> responses = puf.r_eval(5, random_inputs(N=2, n=64, seed=2))
+        >>> responses = puf.r_eval(5, random_inputs(N=2, n=64, seed=4))
         >>> responses[0, :, :]  # unstable example
-        array([[ 1.,  1., -1.,  1.,  1.]])
+        array([[ 1.,  1., -1., -1., -1.]])
         >>> responses[1, :, :]  # stable example
-        array([[-1., -1., -1., -1., -1.]])
+        array([[1., 1., 1., 1., 1.]])
 
         .. note::
             To approximate the expected respones value, use average along the last axis:
 
             >>> from numpy import average
             >>> average(responses, axis=-1)
-            array([[ 0.6],
-                   [-1. ]])
+            array([[-0.2],
+                   [ 1. ]])
         """
         N = challenges.shape[0]
         responses = empty(shape=(N, self.response_length, r))


### PR DESCRIPTION
To fix #165, this changes `XORArbiterPUF` to have random bias configured by default. This necessarily constitutes a breaking change in the sense that the same seed will give different PUF instances when switching to a newer pypuf version.

I used the opportunity to adjust the XOR Arbiter PUF weights to an more accurate model as described in https://ia.cr/2021/555, Corollary 1.

@RRasche your comments are appreciated.